### PR TITLE
Fixes config issues with docs.lotu.sh.

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://docs.lotu.sh/"
+baseurl = "https://lotu.sh/"
 canonifyURLs = false
 disableAliases = true
 disableHugoGeneratorInject = true

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -50,7 +50,7 @@ portraitPhotoWidths = [800, 700, 600, 500]
 lqipWidth = "20x"
 
 # Footer
-footer = "Made by Protocol Labs."
+footer = "Built by Protocol Labs."
 
 # Feed
 copyRight = ""

--- a/content/en/docs/storage-providers/addresses.md
+++ b/content/en/docs/storage-providers/addresses.md
@@ -30,7 +30,7 @@ The owner address corresponds to a Lotus node address provided during the miner 
 - Withdrawing balance from the _miner actor_.
 - Submit _WindowPoSts_, **unless _control addresses_ are defined and have enough balance** (continued below).
 
-The address chosen to be the miner's _owner address_ is designed to be kept offline in _cold storage_, or backed up by a [hardware wallet]({{< relref "../set-up/ledger" >}}). In production environments, we strongly recommend using separate _owner_ and _worker_ addresses.
+The address chosen to be the miner's _owner address_ is designed to be kept offline in _cold storage_, or backed up by a [hardware wallet]({{< relref "../set-up/manage-fil" >}}). In production environments, we strongly recommend using separate _owner_ and _worker_ addresses.
 
 The owner address can be updated with the following command:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,6 @@
       "integrity": "sha512-YW5wOprO2LzMjoWZ5ZG6jfbY9JnkDxuHDwvnrThnuYtByorova/I0HNXJedrUfwuXFQfYOjcqDA4PU3qlZGZjg==",
       "dev": true,
       "dependencies": {
-        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -2410,7 +2408,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4309,7 +4306,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4960,7 +4956,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {


### PR DESCRIPTION
There were some console errors in the main branch. It was because the config file for Hugo was using `docs.lotu.sh` as the base URL. Updated it to use `lotu.sh` instead.

This PR also fixes a link pointing to `addresses`.