### PR TITLE
Clean up extra parentheses

### DIFF
--- a/content/en/docs/set-up/about.md
+++ b/content/en/docs/set-up/about.md
@@ -27,8 +27,8 @@ Lotus is a command line application that **works on Linux and MacOS only**, and 
 These are the main guides to swiftly get started with Lotus:
 
 - [Install and launch a Lotus node]({{< relref "install" >}})
-- [Create a wallet and send or receive FIL to your address]({{< relref "manage-fil" >}}))
-- [Switch between different networks]({{< relref "switch-networks" >}}))
-- [Learn about the Lotus configuration]({{< relref "configuration" >}}))
+- [Create a wallet and send or receive FIL to your address]({{< relref "manage-fil" >}})
+- [Switch between different networks]({{< relref "switch-networks" >}})
+- [Learn about the Lotus configuration]({{< relref "configuration" >}})
 
 Please check the side menu for additional guides!


### PR DESCRIPTION
Some of the "Getting started with Lotus" bullet points on this page have extra parentheses showing up:

![image](https://user-images.githubusercontent.com/460028/143763722-8a9584b5-ea91-42cf-9eb2-88d7480dc9c2.png)
