### PR TITLE
Uncramp tables a bit

### DIFF
--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -4,4 +4,5 @@ table {
 }
 table td, table thead tr th {
   font-size: 85%;
+  padding: 0.6rem;
 }

--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -1,5 +1,7 @@
 table {
   @extend .table;
-
   margin: 3rem 0;
+}
+table td, table thead tr th {
+  font-size: 85%;
 }


### PR DESCRIPTION
Resolves #14 

The issue we have with a very narrow content column is that adding more padding between cells restricts the amount of content at a moment of extreme horizontal scarcity. So in order to accommodate a 20% increase in padding (to un-cramp the tables), I am also shrinking the font size 15%. This is not super noticeable when you're reading the page, and information-dense tables such as "Hardware Requirements" (under Storage Providers), but the net effect is that you have a more "scannable" table with fewer line-wraps and more spacing between ideas. 