### PR TITLE
Adds a details shortcode.

### DIFF
--- a/layouts/shortcodes/details.html
+++ b/layouts/shortcodes/details.html
@@ -1,0 +1,6 @@
+<p>
+    <details>
+        <summary>{{ (.Get 0) | markdownify }}</summary>
+        {{ .Inner | markdownify }}
+    </details>
+</p>


### PR DESCRIPTION
Adds a shortcode to use the `<details>` tag.

## Usage

```markdown
{{< details "Title" >}}
Lorem ipsum.
{{< /details >}}
```