### PR TITLE
updated Glif nodes info connected with limited amount of block, updated link to the calibration network node

### DIFF
--- a/content/en/docs/developers/hosted-lotus.md
+++ b/content/en/docs/developers/hosted-lotus.md
@@ -15,14 +15,14 @@ Developers can interact directly with load-balanced, synced mainnet nodes using 
 
 Unlike bare Lotus, the endpoint above is hardened and limited:
 
-- Only read calls and `MPoolPush()` are supported, please use the link [api.node.glif.io](https://api.node.glif.io) to check the full list.
+- Only read calls and `MPoolPush()` are supported. You can view the full list of available calls at [api.node.glif.io](https://api.node.glif.io).
 - Only POST requests are supported.
 - The Filecoin signing tools can be used to sign messages before submission when needed.
-- Public endpoint guarantees only 2000 of the latest blocks due to the limitation of the [lightweight-snapshots](https://lotus.filecoin.io/docs/set-up/chain-management/#lightweight-snapshot)
-- Filecoin.StateMarketDeals operation data is available as direct link to AWS S3 bucket. StateMarketDeals Data is refreshing every 10 minutes: [link to StateMarketDeals.json](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json)
+- Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
+- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json). `StateMarketDeals` data is refreshed every 10 minutes.
 ## Testnet endpoint
 
-For synced testnet node endpoints using the [JSON RPC API]({{< relref "../apis/json-rpc" >}}), `https://dev.node.glif.io/calibrationapi/lotus/rpc/v0` is available.
+Testnet nodes using the [JSON RPC API]({{< relref "../apis/json-rpc" >}}) can use `https://dev.node.glif.io/calibrationapi/lotus/rpc/v0`.
 
 ### Custom endpoints
 


### PR DESCRIPTION
Hi,

I'm working for Glif.io and supporting and developing infrastructure for hosted nodes. 
A few days ago, I found that we don't have explicit information about the 2k limitation for public nodes and have the wrong link to the calibration network.

Thus I've corrected it and created this PR, please take a look at it.