### PR TITLE
add shortcode for bootstrap tooltips

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -26,6 +26,12 @@ document.addEventListener('click', function(event) {
 
 });
 
+// initialize bootstrap tooltips
+var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+  return new bootstrap.Tooltip(tooltipTriggerEl)
+})
+
 /*
 Source:
   - https://dev.to/shubhamprakash/trap-focus-using-javascript-6a3

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -27,6 +27,7 @@
 @import "components/mermaid";
 @import "components/search";
 @import "components/tables";
+@import "components/tooltips";
 @import "layouts/footer";
 @import "layouts/header";
 @import "layouts/pages";

--- a/assets/scss/components/_tooltips.scss
+++ b/assets/scss/components/_tooltips.scss
@@ -1,0 +1,6 @@
+.tooltip-anchor {
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
+    color: $color-btn-bg;
+}

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -21,69 +21,76 @@ section = ["HTML", "RSS", "SITEMAP"]
 
 # remove .{ext} from text/netlify
 [mediaTypes."text/netlify"]
-suffixes = [""]
 delimiter = ""
+suffixes = [""]
 
 # add output format for netlify _redirects
 [outputFormats.REDIRECTS]
-mediaType = "text/netlify"
 baseName = "_redirects"
 isPlainText = true
+mediaType = "text/netlify"
 notAlternative = true
 
 # add output format for netlify _headers
 [outputFormats.HEADERS]
-mediaType = "text/netlify"
 baseName = "_headers"
 isPlainText = true
+mediaType = "text/netlify"
 notAlternative = true
 
 # add output format for section sitemap.xml
 [outputFormats.SITEMAP]
-mediaType = "application/xml"
 baseName = "sitemap"
 isHTML = false
 isPlainText = true
+mediaType = "application/xml"
 noUgly = true
-rel  = "sitemap"
+rel = "sitemap"
 
 [caches]
-  [caches.getjson]
-    dir = ":cacheDir/:project"
-    maxAge = "10s"
+[caches.getjson]
+dir = ":cacheDir/:project"
+maxAge = "10s"
 
 [sitemap]
-  changefreq = "weekly"
-  filename = "sitemap.xml"
-  priority = 0.5
+changefreq = "weekly"
+filename = "sitemap.xml"
+priority = 0.5
 
 [taxonomies]
-  contributor = "contributors"
+contributor = "contributors"
 
 [permalinks]
-  blog = "/blog/:title/"
+blog = "/blog/:title/"
 # docs = "/docs/1.0/:sections[1:]/:title/"
 
 [minify.tdewolff.html]
-  keepWhitespace = false
+keepWhitespace = false
 
 [module]
-  [module.hugoVersion]
-    extended = true
-    min = "0.80.0"
-    max = ""
-  [[module.mounts]]
-    source = "assets"
-    target = "assets"
-  [[module.mounts]]
-    source = "static"
-    target = "static"
-  [[module.mounts]]
-    source = "node_modules/flexsearch"
-    target = "assets/js/vendor/flexsearch"
-  [[module.mounts]]
-    source = "node_modules/katex"
-    target = "assets/js/vendor/katex"
-  [[module.mounts]]
-    source = "node_modules/mermaid"
-    target = "assets/js/vendor/mermaid"
+[module.hugoVersion]
+extended = true
+max = ""
+min = "0.80.0"
+[[module.mounts]]
+source = "assets"
+target = "assets"
+[[module.mounts]]
+source = "static"
+target = "static"
+[[module.mounts]]
+source = "node_modules/flexsearch"
+target = "assets/js/vendor/flexsearch"
+[[module.mounts]]
+source = "node_modules/katex"
+target = "assets/js/vendor/katex"
+[[module.mounts]]
+source = "node_modules/mermaid"
+target = "assets/js/vendor/mermaid"
+# see https://github.com/h-enk/doks/discussions/281
+[[module.mounts]]
+source = "node_modules/bootstrap"
+target = "assets/js/vendor/bootstrap"
+[[module.mounts]]
+source = "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js.map"
+target = "static/js/vendor/bootstrap/dist/js/bootstrap.bundle.min.js.map"

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -28,6 +28,7 @@ module.exports = {
           './assets/scss/components/_search.scss',
           './assets/scss/common/_dark.scss',
           './node_modules/bootstrap/scss/_dropdown.scss',
+          './node_modules/bootstrap/scss/_tooltip.scss',
           './node_modules/katex/dist/katex.css',
         ]),
       ],

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -1,8 +1,7 @@
 {{ $indexTemplate := resources.Get "js/index.js" -}}
 {{ $index := $indexTemplate | resources.ExecuteAsTemplate "index.js" . -}}
 
-{{ $bs := resources.Get "js/bootstrap.js" -}}
-{{ $bs := $bs | js.Build -}}
+{{ $bs := resources.Get "js/vendor/bootstrap/dist/js/bootstrap.bundle.min.js" -}}
 
 {{ $highlight := resources.Get "js/highlight.js" -}}
 {{ $highlight := $highlight | js.Build -}}

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,0 +1,8 @@
+<a
+  href="#" 
+  class="tooltip-anchor"
+  data-bs-toggle="tooltip"
+  title="{{ .Get 0 }}"
+  data-bs-placement='{{ if (.Get 1) }}{{ .Get 1 }}{{ else }}top{{ end }}'>
+  {{ .Inner }}
+</a>


### PR DESCRIPTION
This enables bootstrap tooltips and adds a `tooltip` shortcode you can use like so:

```markdown
As an {{% tooltip "This is a tooltip!" %}}alternative{{% /tooltip %}} to running locally, you can also run Lotus on a cloud provider. The easiest and cheapest path is to use [the one-click application in the DigitalOcean marketplace](https://marketplace.digitalocean.com/apps/filecoin-lotus).
```

That gives you something like this:

![lotus-tooltip](https://user-images.githubusercontent.com/678715/154158516-1bace737-9f49-4416-8cf2-1cab01a23ffd.gif)

You have to quote the tooltip text in `"` characters or it will only get the first word..

Closes #13 