### PR TITLE
Add JSON endpoint at /algolia

### DIFF
--- a/content/en/algolia.md
+++ b/content/en/algolia.md
@@ -1,0 +1,4 @@
+---
+title: Algolia JSON
+layout: algolia
+---

--- a/layouts/_default/algolia.html
+++ b/layouts/_default/algolia.html
@@ -1,0 +1,5 @@
+{{- $.Scratch.Add "index" slice -}}
+{{- range .Site.RegularPages -}}
+  {{- $.Scratch.Add "index" (dict "title" .Title "description" .Params.description "contents" .Plain "RelPermalink" .RelPermalink) -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
Adds JSON output for Lotus docs at https://lotus.filecoin.io/algolia/

This can be indexed by Algolia and help us enable cross-site indexing