### PR TITLE
Fix typo in index provider docs

### DIFF
--- a/content/en/docs/storage-providers/index-provider.md
+++ b/content/en/docs/storage-providers/index-provider.md
@@ -168,9 +168,9 @@ Note that if you have split your markets subsystem, you will need to specify `--
 
 ## Configuration
 
-You can adjust the values under the `IndexProvider` session in the `config.toml` of your market process to configure indexes' announcement to the indexer.
+You can adjust the values under the `IndexProvider` section in the `config.toml` of your market process to configure indexes' announcement to the indexer.
 
-If the session doesn't exist, you can manually add it:
+If the section doesn't exist, you can manually add it:
 
 ```toml
 [IndexProvider]


### PR DESCRIPTION
Replace session with section as pointed out in:
- https://github.com/filecoin-project/lotus-docs/pull/92#discussion_r824927087