### PR TITLE
Renaming to storage providers

### DIFF
--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -17,8 +17,8 @@ There are several ways to install Lotus on macOS:
 - [Install with Homebrew](#install-with-homebrew).
 - [Build from source](#build-from-source).
 
-{{< alert icon="warning">}}**Miners should build from source.**
-Building Lotus from source allows you to strictly configure how Lotus runs and how it communicates with its dependencies. Miners looking to improve their system efficiency should [install Lotus by building from source](#build-from-source).
+{{< alert icon="warning">}}**Storage providers should build from source.**
+Building Lotus from source allows you to strictly configure how Lotus runs and how it communicates with its dependencies. Storage providers looking to improve their system efficiency should [install Lotus by building from source](#build-from-source).
 {{< /alert >}}
 
 ## Install with Homebrew

--- a/content/en/lotus/install/prerequisites.md
+++ b/content/en/lotus/install/prerequisites.md
@@ -24,7 +24,7 @@ To run a Lotus node your computer must have:
 - Enough space to store the current Lotus chain (preferably on an SSD storage medium). The chain grows at approximately 38 GiB per day. The chain can be [synced from trusted state snapshots and compacted or pruned]({{< relref "chain-management" >}}) to a minimum size of around 33Gib.  The full history was around 10TiB in June of 2021.
 
 {{< alert icon="warning" >}}
-These are the minimal requirements to run a Lotus node. [Hardware requirements for Miners]({{< relref "hardware-requirements" >}}) are different.
+These are the minimal requirements to run a Lotus node. [Hardware requirements for storage providers]({{< relref "hardware-requirements" >}}) are different.
 {{< /alert >}}
 
 ## Nodes in China

--- a/content/en/lotus/install/ubuntu.md
+++ b/content/en/lotus/install/ubuntu.md
@@ -17,9 +17,9 @@ There are several ways to install Lotus on Linux:
 + [AppImages](#appimage)
 + [Building from source](#building-from-source).
 
-{{< alert icon="warning">}}**Miners should build from source**.
+{{< alert icon="warning">}}**Storage providers should build from source**.
 
-Building Lotus from source allows you to strictly configure how Lotus runs and how it communicates with its dependencies. Miners looking to improve their system efficiency should [install Lotus by building from source](#building-from-source).
+Building Lotus from source allows you to strictly configure how Lotus runs and how it communicates with its dependencies. Storage providers looking to improve their system efficiency should [install Lotus by building from source](#building-from-source).
 {{< /alert >}}
 
 ## Snap package manager


### PR DESCRIPTION
Renaming from Miner to storage providers in the install-section. Should fix #106 