### PR TITLE
Adds missing alias for Lotus install.

### DIFF
--- a/content/en/lotus/install/prerequisites.md
+++ b/content/en/lotus/install/prerequisites.md
@@ -8,6 +8,7 @@ menu:
         identifier: "lotus-install-prerequisites"
 aliases:
     - /docs/set-up/install/
+    - /get-started/lotus/installation
 weight: 110
 toc: true
 ---


### PR DESCRIPTION
Users going to `/get-started/lotus/installation` were getting 404ed and pushed to the Lotus Docs homepage. This PR correctly redirects them to the start of the install process.