### PR TITLE
Audit of economics-page

### DIFF
--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -33,7 +33,7 @@ The mechanism to earn the right to _provide_ a new block is called _WinningPoSt_
 
 The number of blocks on every tipset is based on a Poisson distribution of a random variable with λ = 5. Provider implementations may use several strategies to choose which messages to include in every block to minimize overlap. Only the "first execution" of each message will collect the associated fees, with executions ordered per the hash of the VRF (Verifiable Random Function) ticket associated to the block.
 
-When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your storage provider actor's available balance and the rest 75% will become locked funds and be released linearly in 180 days.
+When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your storage provider actor's available balance and the remaining 75% will become locked funds and be released linearly in 180 days.
 
 ### Verified clients
 

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -17,9 +17,9 @@ There are two main types of rewards for their efforts: storage fees and block re
 
 ### Storage fees
 
-_PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage providers set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
+_PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage provider’s set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
 
-**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider´s associated withdrawal wallet as they continue to perform their duties over time and are briefly locked upon being received.
+**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider´s associated withdrawal wallet as they continue to perform their duties over time, and are briefly locked upon being received.
 
 ### Block rewards
 
@@ -33,7 +33,7 @@ The mechanism to earn the right to _provide_ a new block is called _WinningPoSt_
 
 The number of blocks on every tipset is based on a Poisson distribution of a random variable with λ = 5. Provider implementations may use several strategies to choose which messages to include in every block to minimize overlap. Only the "first execution" of each message will collect the associated fees, with executions ordered per the hash of the VRF (Verifiable Random Function) ticket associated to the block.
 
-When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your storage providers actor's available balance and the rest 75% will become locked funds and be released linearly in 180 days.
+When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your storage provider actor's available balance and the rest 75% will become locked funds and be released linearly in 180 days.
 
 ### Verified clients
 
@@ -61,19 +61,19 @@ This penalty is incurred when committing consensus faults. This penalty is appli
 
 ## Storage provider accounting
 
-A Storage providers financial gain or loss is affected by the following three actions:
+A Storage provider’s financial gain or loss is affected by the following three actions:
 
 1. The deposited tokens to act as collateral for their PreCommitted and ProveCommitted Sectors
-2. Storage providers earn tokens from block rewards, when they are elected to mine a new block and extend the blockchain.
+2. Storage providers earn tokens from block rewards when they are elected to mine a new block and extend the blockchain.
 3. Storage providers lose tokens if they fail to prove storage of a sector and are given penalties as a result.
 
 ### Balance requirements
 
-A storage providers token balance MUST cover ALL of the following:
+A storage provider’s token balance MUST cover ALL of the following:
 
 - **PreCommit Deposits**: When a storage provider PreCommits a Sector, they must supply a "precommit deposit" for the Sector, which acts as collateral. If the Sector is not ProveCommitted on time, this deposit is removed and burned.
 - **Initial Pledge**: When a storage provider ProveCommits a Sector, they must supply an "initial pledge" for the Sector, which acts as collateral. If the Sector is terminated, this deposit is removed and burned along with rewards earned by this sector up to a limit.
-- **Locked Funds**: When a storage provider receives tokens from block rewards, the tokens are locked and added to the storage providers vesting table to be unlocked linearly over future epochs.
+- **Locked Funds**: When a storage provider receives tokens from block rewards, the tokens are locked and added to the storage provider vesting table to be unlocked linearly over future epochs.
 
 ### Faults, Penalties and Fee Debt
 
@@ -83,6 +83,6 @@ A Sector's PoSts must be submitted on time, or that Sector is marked "faulty." T
 
 - **Declared Fault**: When the storage provider explicitly declares a Sector "faulty" _before_ its Deadline's FaultCutoff. Recall that `WindowPoSt` proofs are submitted per partition for a specific `ChallengeWindow`. A storage provider has to declare the sector as faulty before the `ChallengeWindow` for the particular partition opens. Until the sectors are recovered they will be masked from proofs in subsequent proving periods.
 - **Detected Fault**: Partitions of sectors without PoSt proof verification records, which have not been declared faulty before the `FaultCutoff` epoch's deadline are marked as detected faults.
-- **Skipped Fault**: If a sector is currently in active or recovering state and has not been declared faulty before, but the storage providers PoSt submission does not include a proof for this sector, then this is a "skipped fault" sector (also referred to as "skipped undeclared fault"). In other words, when a storage provider submits PoSt proofs for a partition but does not include proofs for some sectors in the partition, then these sectors are in "skipped fault" state. This is in contrast to the "detected fault" state, where the storage provider does not submit a PoSt proof for any section in the partition at all. The skipped fault is helpful in case a sector becomes faulty after the `FaultCutoff` epoch. Skip faults happen when windowPost process is not able to acquire certain sectors on the disk during the dealine. These sectors an be found in the wdPost message submitted to the chain.
+- **Skipped Fault**: If a sector is currently in active or recovering state and has not been declared faulty before, but the storage provider’s PoSt submission does not include a proof for this sector, then this is a "skipped fault" sector (also referred to as "skipped undeclared fault"). In other words, when a storage provider submits PoSt proofs for a partition but does not include proofs for some sectors in the partition, then these sectors are in "skipped fault" state. This is in contrast to the "detected fault" state, where the storage provider does not submit a PoSt proof for any section in the partition at all. The skipped fault is helpful in case a sector becomes faulty after the `FaultCutoff` epoch. Skip faults happen when windowPost process is not able to acquire certain sectors on the disk during the dealine. These sectors an be found in the wdPost message submitted to the chain.
 
 Note that the "skipped fault" allows for sector-wise fault penalties, as compared to partition-wide faults and penalties, as is the case with "detected faults".

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -19,7 +19,7 @@ There are two main types of rewards for their efforts: storage fees and block re
 
 _PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage provider’s set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
 
-**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider´s associated withdrawal wallet as they continue to perform their duties over time, and are briefly locked upon being received.
+**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider’s associated withdrawal wallet as they continue to perform their duties over time, and are briefly locked upon being received.
 
 ### Block rewards
 

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -61,7 +61,7 @@ This penalty is incurred when committing consensus faults. This penalty is appli
 
 ## Storage provider accounting
 
-A Storage provider’s financial gain or loss is affected by the following three actions:
+A storage provider’s financial gain or loss is affected by the following three actions:
 
 1. The deposited tokens to act as collateral for their PreCommitted and ProveCommitted Sectors
 2. Storage providers earn tokens from block rewards when they are elected to mine a new block and extend the blockchain.

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -17,24 +17,23 @@ There are two main types of rewards for their efforts: storage fees and block re
 
 ### Storage fees
 
-_PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage providers’s set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
+_PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage providers set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
 
-**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a providers's associated withdrawal wallet as they continue to perform their duties over time, and are briefly locked upon being received.
+**Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider´s associated withdrawal wallet as they continue to perform their duties over time and are briefly locked upon being received.
 
 ### Block rewards
 
 **Block rewards** are large sums that are given to the storage provider credited for a new block. Unlike storage fees, these rewards do not come from an associated client; rather, the network "prints" new FIL as both an inflationary measure and an incentive to providers advancing the chain. All active storage providers on the network have a chance at receiving a block reward, their chance at such being directly proportional to the amount of storage space currently being contributed to the network.
 
 {{< alert icon="warning" >}}
-A storage provider needs to have 10 TiB minimum power in the network to be eligible for block rewards.
+A storage provider needs to have 10 TiB minimum raw power in the network to be eligible for block rewards.
 {{< /alert >}}
-
  
 The mechanism to earn the right to _provide_ a new block is called _WinningPoSt_. In the Filecoin network, time is discretized into a series of epochs – the blockchain's height corresponds to the number of elapsed epochs. At the beginning of each epoch, a small number of storage providers are elected to provide new blocks. Additionally to the block reward, each storage provider can collect the fees associated to each message included in the block.
 
 The number of blocks on every tipset is based on a Poisson distribution of a random variable with λ = 5. Provider implementations may use several strategies to choose which messages to include in every block to minimize overlap. Only the "first execution" of each message will collect the associated fees, with executions ordered per the hash of the VRF (Verifiable Random Function) ticket associated to the block.
 
-When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your miner actor's available balance and the rest 75% will become locked funds and be released linearly in 180 days.
+When storage provider get block rewards from the network, 25% percent of the reward will be immediately released to your storage providers actor's available balance and the rest 75% will become locked funds and be released linearly in 180 days.
 
 ### Verified clients
 
@@ -43,7 +42,6 @@ To further incentivize the storage of "useful" data over simple capacity commitm
 ### Retrieval fees
 
 Retrieval fees are paid incrementally using _payment channels_ as the retrieval deals are fulfilled (by sending portions of the data to the client. This happens off-chain.
-
 
 ## Penalty
 
@@ -61,21 +59,21 @@ This term encompasses a broader set of penalties which are to be paid by storage
 
 This penalty is incurred when committing consensus faults. This penalty is applied to storage providers that have acted maliciously against the network's consensus functionality.
 
-## Miner Accounting
+## Storage provider accounting
 
-A Miner's financial gain or loss is affected by the following three actions:
+A Storage providers financial gain or loss is affected by the following three actions:
 
-1. Miners deposit tokens to act as collateral for their PreCommitted and ProveCommitted Sectors
-2. Miners earn tokens from block rewards, when they are elected to mine a new block and extend the blockchain.
-3. Miners lose tokens if they fail to prove storage of a sector and are given penalties as a result.
+1. The deposited tokens to act as collateral for their PreCommitted and ProveCommitted Sectors
+2. Storage providers earn tokens from block rewards, when they are elected to mine a new block and extend the blockchain.
+3. Storage providers lose tokens if they fail to prove storage of a sector and are given penalties as a result.
 
-### Balance Requirements
+### Balance requirements
 
-A Miner's token balance MUST cover ALL of the following:
+A storage providers token balance MUST cover ALL of the following:
 
-- **PreCommit Deposits**: When a Miner PreCommits a Sector, they must supply a "precommit deposit" for the Sector, which acts as collateral. If the Sector is not ProveCommitted on time, this deposit is removed and burned.
-- **Initial Pledge**: When a Miner ProveCommits a Sector, they must supply an "initial pledge" for the Sector, which acts as collateral. If the Sector is terminated, this deposit is removed and burned along with rewards earned by this sector up to a limit.
-- **Locked Funds**: When a Miner receives tokens from block rewards, the tokens are locked and added to the Miner's vesting table to be unlocked linearly over some future epochs.
+- **PreCommit Deposits**: When a storage provider PreCommits a Sector, they must supply a "precommit deposit" for the Sector, which acts as collateral. If the Sector is not ProveCommitted on time, this deposit is removed and burned.
+- **Initial Pledge**: When a storage provider ProveCommits a Sector, they must supply an "initial pledge" for the Sector, which acts as collateral. If the Sector is terminated, this deposit is removed and burned along with rewards earned by this sector up to a limit.
+- **Locked Funds**: When a storage provider receives tokens from block rewards, the tokens are locked and added to the storage providers vesting table to be unlocked linearly over future epochs.
 
 ### Faults, Penalties and Fee Debt
 
@@ -83,8 +81,8 @@ A Miner's token balance MUST cover ALL of the following:
 
 A Sector's PoSts must be submitted on time, or that Sector is marked "faulty." There are three types of faults:
 
-- **Declared Fault**: When the Miner explicitly declares a Sector "faulty" _before_ its Deadline's FaultCutoff. Recall that `WindowPoSt` proofs are submitted per partition for a specific `ChallengeWindow`. A miner has to declare the sector as faulty before the `ChallengeWindow` for the particular partition opens. Until the sectors are recovered they will be masked from proofs in subsequent proving periods.
+- **Declared Fault**: When the storage provider explicitly declares a Sector "faulty" _before_ its Deadline's FaultCutoff. Recall that `WindowPoSt` proofs are submitted per partition for a specific `ChallengeWindow`. A storage provider has to declare the sector as faulty before the `ChallengeWindow` for the particular partition opens. Until the sectors are recovered they will be masked from proofs in subsequent proving periods.
 - **Detected Fault**: Partitions of sectors without PoSt proof verification records, which have not been declared faulty before the `FaultCutoff` epoch's deadline are marked as detected faults.
-- **Skipped Fault**: If a sector is currently in active or recovering state and has not been declared faulty before, but the miner's PoSt submission does not include a proof for this sector, then this is a "skipped fault" sector (also referred to as "skipped undeclared fault"). In other words, when a miner submits PoSt proofs for a partition but does not include proofs for some sectors in the partition, then these sectors are in "skipped fault" state. This is in contrast to the "detected fault" state, where the miner does not submit a PoSt proof for any section in the partition at all. The skipped fault is helpful in case a sector becomes faulty after the `FaultCutoff` epoch. Skip faults happen when windowPost process is not able to acquire certain sectors on the disk during the dealine. These sectors an be found in the wdPost message submitted to the chain.
+- **Skipped Fault**: If a sector is currently in active or recovering state and has not been declared faulty before, but the storage providers PoSt submission does not include a proof for this sector, then this is a "skipped fault" sector (also referred to as "skipped undeclared fault"). In other words, when a storage provider submits PoSt proofs for a partition but does not include proofs for some sectors in the partition, then these sectors are in "skipped fault" state. This is in contrast to the "detected fault" state, where the storage provider does not submit a PoSt proof for any section in the partition at all. The skipped fault is helpful in case a sector becomes faulty after the `FaultCutoff` epoch. Skip faults happen when windowPost process is not able to acquire certain sectors on the disk during the dealine. These sectors an be found in the wdPost message submitted to the chain.
 
 Note that the "skipped fault" allows for sector-wise fault penalties, as compared to partition-wide faults and penalties, as is the case with "detected faults".

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -17,7 +17,7 @@ There are two main types of rewards for their efforts: storage fees and block re
 
 ### Storage fees
 
-_PoSt (Proof-of-Spacetime)_ window checks are performed on 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage provider’s set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
+_PoSt (Proof-of-Spacetime)_ window checks are performed at 24 hour intervals across the network to ensure that storage providers are continuing to host their required sectors as normal. Correspondingly, each storage provider’s set of pledged sectors is partitioned into subsets, one subset for each window. Within a given window, each storage provider must submit a PoSt for each sector in their respective subset. For each day a storage provider is inactive it will receive a [fault fee](#penalty).
 
 **Storage fees** are the fees paid regularly by clients after a deal has been reached, in exchange for storing data. These fees are automatically deposited into a provider’s associated withdrawal wallet as they continue to perform their duties over time, and are briefly locked upon being received.
 


### PR DESCRIPTION
Audit of the `get-started/economics` page. I think this page is mostly fine as is, only changed the term `Miner` to `Storage provider`