### PR TITLE
Adjust weights across SP-page

### DIFF
--- a/content/en/storage-providers/advanced-configurations/logging.md
+++ b/content/en/storage-providers/advanced-configurations/logging.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     storage-providers:
         parent: "storage-providers-advanced-configurations"
-weight: 160
+weight: 525
 toc: true
 ---
 

--- a/content/en/storage-providers/advanced-configurations/market.md
+++ b/content/en/storage-providers/advanced-configurations/market.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     storage-providers:
         parent: "storage-providers-advanced-configurations"
-weight: 120
+weight: 510
 toc: true
 ---
 

--- a/content/en/storage-providers/advanced-configurations/sealing.md
+++ b/content/en/storage-providers/advanced-configurations/sealing.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     storage-providers:
         parent: "storage-providers-advanced-configurations"
-weight: 120
+weight: 515
 toc: true
 ---
 

--- a/content/en/storage-providers/advanced-configurations/split-markets-miners/index.md
+++ b/content/en/storage-providers/advanced-configurations/split-markets-miners/index.md
@@ -10,7 +10,7 @@ menu:
 aliases:
     - /docs/storage-providers/split-markets-miners/
     - /storage-providers/configure/split-markets-miners/
-weight: 130
+weight: 520
 toc: true
 ---
 

--- a/content/en/storage-providers/advanced-configurations/workers.md
+++ b/content/en/storage-providers/advanced-configurations/workers.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     storage-providers:
         parent: "storage-providers-advanced-configurations"
-weight: 110
+weight: 505
 toc: true
 ---
 

--- a/content/en/storage-providers/get-started/architectures/index.md
+++ b/content/en/storage-providers/get-started/architectures/index.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-providers-architectures"
 aliases:
     - /docs/storage-providers/mining-architectures/
-weight: 150
+weight: 125
 toc: true
 ---
 

--- a/content/en/storage-providers/get-started/economics.md
+++ b/content/en/storage-providers/get-started/economics.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-get-started"
         identifier: "storage-providers-economics"
-weight: 130
+weight: 115
 toc: true
 ---
 

--- a/content/en/storage-providers/get-started/hardware-requirements.md
+++ b/content/en/storage-providers/get-started/hardware-requirements.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-providers-hardware-requirements"
 aliases:
     - /docs/storage-providers/hardware-requirements/
-weight: 140
+weight: 120
 toc: true
 ---
 

--- a/content/en/storage-providers/get-started/overview/index.md
+++ b/content/en/storage-providers/get-started/overview/index.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-providers-overview"
 aliases:
     - /docs/storage-providers/overview/
-weight: 110
+weight: 105
 toc: true
 ---
 

--- a/content/en/storage-providers/get-started/tasks/index.md
+++ b/content/en/storage-providers/get-started/tasks/index.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-get-started"
         identifier: "storage-providers-tasks"
-weight: 120
+weight: 110
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/addresses.md
+++ b/content/en/storage-providers/operate/addresses.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-addresses"
 aliases:
     - /docs/storage-providers/addresses/
-weight: 120
+weight: 310
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/backup-and-restore.md
+++ b/content/en/storage-providers/operate/backup-and-restore.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-backup-and-restore"
 aliases:
     - /docs/storage-providers/backup-and-restore/
-weight: 140
+weight: 325
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/benchmarks.md
+++ b/content/en/storage-providers/operate/benchmarks.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-benchmarks"
 aliases:
     - /docs/storage-providers/benchmarks/
-weight: 110
+weight: 305
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/connectivity.md
+++ b/content/en/storage-providers/operate/connectivity.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provier-connectivity"
 aliases:
     - /docs/storage-providers/connectivity/
-weight: 130
+weight: 320
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/custom-storage-layout.md
+++ b/content/en/storage-providers/operate/custom-storage-layout.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-providers-configure-custom-storage-layout"
 aliases:
     - /docs/storage-providers/custom-storage-layout/
-weight: 120
+weight: 315
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/dagstore.md
+++ b/content/en/storage-providers/operate/dagstore.md
@@ -10,7 +10,7 @@ menu:
 aliases:
     - /docs/storage-providers/dagstore/
     - /storage-providers/configure/dagstore/
-weight: 160
+weight: 335
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/disputer.md
+++ b/content/en/storage-providers/operate/disputer.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-operate-disputer"
 aliases:
     - /docs/storage-providers/disputer/
-weight: 190
+weight: 355
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/dynamic-retrieval-pricing.md
+++ b/content/en/storage-providers/operate/dynamic-retrieval-pricing.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-dynamic-retrieval-pricing"
 aliases:
     - /docs/storage-providers/dynamic-retrieval-pricing/
-weight: 180
+weight: 350
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/index-provider.md
+++ b/content/en/storage-providers/operate/index-provider.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-operate"
         identifier: "storage-providers-index-provider"
-weight: 191
+weight: 360
 aliases:
     - /docs/storage-providers/index-provider/
 toc: true

--- a/content/en/storage-providers/operate/journal.md
+++ b/content/en/storage-providers/operate/journal.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-journal"
 aliases:
     - /docs/storage-providers/miner-journal/
-weight: 200
+weight: 365
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/lotus-miner-cli.md
+++ b/content/en/storage-providers/operate/lotus-miner-cli.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-operate"
         identifier: "storage-provider-lotus-miner-cli"
-weight: 220
+weight: 375
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/maintenance.md
+++ b/content/en/storage-providers/operate/maintenance.md
@@ -10,7 +10,7 @@ menu:
 aliases:
     - /docs/storage-providers/lifecycle/
     - /storage-providers/configure/lifecycle/
-weight: 455
+weight: 385
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/manage-storage-deals.md
+++ b/content/en/storage-providers/operate/manage-storage-deals.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-manage-storage-deals"
 aliases:
     - /docs/storage-providers/manage-storage-deals/
-weight: 170
+weight: 345
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/message-pool.md
+++ b/content/en/storage-providers/operate/message-pool.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-message-pool"
 aliases:
     - /docs/storage-providers/message-pool/
-weight: 210
+weight: 370
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/sector-pledging.md
+++ b/content/en/storage-providers/operate/sector-pledging.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-sector-pledging"
 aliases:
     - /docs/storage-providers/sector-pledging/
-weight: 160
+weight: 340
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/snap-deals/index.md
+++ b/content/en/storage-providers/operate/snap-deals/index.md
@@ -8,7 +8,7 @@ menu:
         parent: "storage-providers-operate"
 aliases:
     - /storage-providers/configure/snap-deals/
-weight: 492
+weight: 390
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/troubleshooting.md
+++ b/content/en/storage-providers/operate/troubleshooting.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-troubleshooting"
 aliases:
     - /docs/storage-providers/troubleshooting/
-weight: 230
+weight: 380
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/upgrades.md
+++ b/content/en/storage-providers/operate/upgrades.md
@@ -9,7 +9,7 @@ menu:
         identifier: "storage-provider-upgrades"
 aliases:
     - /docs/storage-providers/upgrades/
-weight: 150
+weight: 330
 toc: true
 ---
 

--- a/content/en/storage-providers/seal-workers/post-workers.md
+++ b/content/en/storage-providers/seal-workers/post-workers.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     storage-providers:
         parent: "storage-providers-seal-workers"
-weight: 120
+weight: 410
 toc: true
 ---
 

--- a/content/en/storage-providers/seal-workers/seal-workers.md
+++ b/content/en/storage-providers/seal-workers/seal-workers.md
@@ -8,7 +8,7 @@ menu:
         parent: "storage-providers-seal-workers"
 aliases:
     - /docs/storage-providers/seal-workers/
-weight: 110
+weight: 405
 toc: true
 ---
 

--- a/content/en/storage-providers/setup/configuration.md
+++ b/content/en/storage-providers/setup/configuration.md
@@ -10,7 +10,7 @@ menu:
 aliases:
     - /docs/storage-providers/config/
     - storage-providers/configure/configuration/
-weight: 120
+weight: 215
 toc: true
 ---
 

--- a/content/en/storage-providers/setup/initialize.md
+++ b/content/en/storage-providers/setup/initialize.md
@@ -10,7 +10,7 @@ menu:
 aliases:
     - /docs/storage-providers/setup/
     - /storage-providers/configure/setup/
-weight: 110
+weight: 210
 toc: true
 ---
 

--- a/content/en/storage-providers/setup/prerequisites.md
+++ b/content/en/storage-providers/setup/prerequisites.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-setup"
         identifier: "storage-providers-setup-prerequisites"
-weight: 100
+weight: 205
 toc: true
 ---
 


### PR DESCRIPTION
Adjusts the weights across all the pages in the /Storage -Provider/-page.

Every sections add +100 in weight, while each page in a given section add +5 to leave room for additional pages in between. The first page of a section starts at x05.

This should allow the page link/button to link to the next page in a top-to-bottom approach. The rebalancing of weight in this commit should leave the current structure intact.