### PR TITLE
Adjust weights across Lotus-pages

### DIFF
--- a/content/en/lotus/configure/bootrap-nodes.md
+++ b/content/en/lotus/configure/bootrap-nodes.md
@@ -9,7 +9,7 @@ menu:
         identifier: "bootstrap-nodes"
 aliases:
     - /docs/set-up/bootstrappers/
-weight: 140
+weight: 315
 toc: true
 ---
 

--- a/content/en/lotus/configure/defaults.md
+++ b/content/en/lotus/configure/defaults.md
@@ -9,7 +9,7 @@ menu:
         identifier: "lotus-configure-defaults"
 aliases:
     - /docs/set-up/configuration/
-weight: 110
+weight: 305
 toc: true
 ---
 

--- a/content/en/lotus/configure/nodes-in-china.md
+++ b/content/en/lotus/configure/nodes-in-china.md
@@ -8,6 +8,7 @@ menu:
         parent: "lotus-configure"
 aliases:
     - /docs/set-up/nodes-in-china/
+weight: 320
 toc: true
 ---
 

--- a/content/en/lotus/get-started/networks.md
+++ b/content/en/lotus/get-started/networks.md
@@ -8,7 +8,7 @@ menu:
         identifier: "lotus-get-started-networks"
 aliases:
     - /about-filecoin/networks
-weight: 130
+weight: 110
 toc: true
 ---
 

--- a/content/en/lotus/get-started/use-cases.md
+++ b/content/en/lotus/get-started/use-cases.md
@@ -9,7 +9,7 @@ menu:
         identifier: "types-of-node"
 aliases:
     - /build/examples
-weight: 140
+weight: 115
 toc: true
 ---
 

--- a/content/en/lotus/get-started/what-is-lotus/index.md
+++ b/content/en/lotus/get-started/what-is-lotus/index.md
@@ -9,7 +9,7 @@ aliases:
     - /docs/getting-started/what-is-lotus/
     - /docs/set-up/about/
     - /docs/
-weight: 110
+weight: 105
 toc: true
 ---
 

--- a/content/en/lotus/install/cloud-services.md
+++ b/content/en/lotus/install/cloud-services.md
@@ -8,7 +8,7 @@ menu:
         identifier: "lotus-install-identifier"
 aliases:
     - /docs/set-up/running-in-the-cloud/
-weight: 140
+weight: 220
 toc: true
 ---
 

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -5,7 +5,7 @@ draft: false
 menu:
     lotus:
          parent: "lotus-install"
-weight: 120
+weight: 210
 toc: true
 ---
 

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-configure"
 alises:
     - /docs/set-up/lotus-lite/
-weight: 130
+weight: 310
 toc: true
 ---
 

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -6,7 +6,7 @@ menu:
     lotus:
          parent: "lotus-install"
          identifier: "lotus-install-macos"
-weight: 130
+weight: 215
 toc: true
 ---
 

--- a/content/en/lotus/install/prerequisites.md
+++ b/content/en/lotus/install/prerequisites.md
@@ -9,7 +9,7 @@ menu:
 aliases:
     - /docs/set-up/install/
     - /get-started/lotus/installation
-weight: 110
+weight: 205
 toc: true
 ---
 

--- a/content/en/lotus/manage/backup-and-restore.md
+++ b/content/en/lotus/manage/backup-and-restore.md
@@ -9,7 +9,7 @@ menu:
         identifier: "lotus-management-backup-and-restore"
 aliases:
     - /docs/set-up/backup-and-restore/
-weight: 150
+weight: 425
 toc: true
 ---
 

--- a/content/en/lotus/manage/chain-management.md
+++ b/content/en/lotus/manage/chain-management.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     - /docs/set-up/chain-management/
-weight: 130
+weight: 415
 toc: true
 ---
 

--- a/content/en/lotus/manage/lotus-cli.md
+++ b/content/en/lotus/manage/lotus-cli.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     - /docs/apis/cli/
-weight: 180
+weight: 440
 toc: true
 ---
 

--- a/content/en/lotus/manage/manage-fil/index.md
+++ b/content/en/lotus/manage/manage-fil/index.md
@@ -9,7 +9,7 @@ menu:
 aliases:
     - /docs/set-up/manage-fil/
     - /get-started/lotus/send-and-receive-fil
-weight: 110
+weight: 405
 toc: true
 ---
 

--- a/content/en/lotus/manage/multisig.md
+++ b/content/en/lotus/manage/multisig.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     - /docs/set-up/multisig/
-weight: 120
+weight: 410
 toc: true
 ---
 

--- a/content/en/lotus/manage/switch-networks.md
+++ b/content/en/lotus/manage/switch-networks.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     - /docs/set-up/switch-networks/
-weight: 140
+weight: 420
 toc: true
 ---
 

--- a/content/en/lotus/manage/troubleshooting.md
+++ b/content/en/lotus/manage/troubleshooting.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     - /docs/set-up/troubleshooting/
-weight: 170
+weight: 435
 toc: true
 ---
 

--- a/content/en/lotus/manage/upgrade.md
+++ b/content/en/lotus/manage/upgrade.md
@@ -8,7 +8,7 @@ menu:
         parent: "lotus-management"
 aliases:
     /docs/set-up/upgrade/
-weight: 160
+weight: 430
 toc: true
 ---
 

--- a/content/en/lotus/project/contribute.md
+++ b/content/en/lotus/project/contribute.md
@@ -8,7 +8,7 @@ menu:
          parent: "project"
 aliases:
     - /docs/project/contribute/
-weight: 120
+weight: 505
 toc: true
 ---
 


### PR DESCRIPTION
Adjusts the weights across all the pages in /Lotus/....

Every sections add +100 in weight, while each page in a given section add +5 to leave room for additional pages in between. The first page of a section starts at x05.

This should allow the page link/button at the bottom to link to the next page in a top-to-bottom approach. The rebalancing of weight in this commit should leave the current structure intact.

- [x] Check that the structure is intact, and that the bottom page link/button links to the next correct page across all the pages.