### PR TITLE
Adjust weights across Developer-pages

### DIFF
--- a/content/en/developers/api-access/index.md
+++ b/content/en/developers/api-access/index.md
@@ -8,7 +8,7 @@ menu:
              parent: "developers-apis"
 aliases:
     - /docs/developers/api-access/
-weight: 110
+weight: 205
 toc: true
 ---
 

--- a/content/en/developers/glif-nodes.md
+++ b/content/en/developers/glif-nodes.md
@@ -7,7 +7,7 @@ menu:
              parent: "developers-nodes"
 aliases:
     - /docs/developers/hosted-lotus/
-weight: 130
+weight: 105
 toc: true
 ---
 

--- a/content/en/developers/local-network.md
+++ b/content/en/developers/local-network.md
@@ -7,7 +7,7 @@ menu:
     developers:
         parent: "developers-networks"
         identifier: "developers-networks-local-network"
-weight: 310
+weight: 305
 toc: true
 aliases:
     - /docs/developers/developer-network

--- a/content/en/developers/troubleshooting.md
+++ b/content/en/developers/troubleshooting.md
@@ -9,7 +9,7 @@ menu:
              identifier: "developers-apis-troubleshooting"
 aliases:
     - /docs/developers/troubleshooting/
-weight: 140 
+weight: 210 
 toc: true
 ---
 


### PR DESCRIPTION
Adjusting the weights across all the pages in /Developer/....

Every sections add +100 in weight, while each page in a given section add +5 to leave room for additional pages in between. The first page of a section starts at x05.

This should allow the page link/button at the bottom to link to the next page in a top-to-bottom approach. The rebalancing of weight in this commit should leave the current structure intact.

- [ ] Check that the structure is intact, and that the bottom page link/button links to the next correct page across all the pages.