### PR TITLE
Adjust weights across Tutorial-pages

### DIFF
--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-providers"
-weight: 120
+weight: 210
 toc: true
 ---
 

--- a/content/en/tutorials/lotus-miner/cuda.md
+++ b/content/en/tutorials/lotus-miner/cuda.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-providers"
-weight: 130
+weight: 215
 toc: true
 ---
 

--- a/content/en/tutorials/lotus-miner/msig-as-owner.md
+++ b/content/en/tutorials/lotus-miner/msig-as-owner.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-providers"
-weight: 140
+weight: 220
 toc: true
 ---
 

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-providers"
-weight: 110
+weight: 205
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -6,7 +6,7 @@ menu:
     tutorials:
         parent: "tutorials-lotus"
 aliases:
-weight: 165
+weight: 135
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/import-data-from-ipfs.md
+++ b/content/en/tutorials/lotus/import-data-from-ipfs.md
@@ -8,7 +8,7 @@ menu:
         parent: "tutorials-lotus"
 aliases:
     - /docs/developers/import-data-from-ipfs/
-weight: 140
+weight: 120
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/large-files.md
+++ b/content/en/tutorials/lotus/large-files.md
@@ -9,7 +9,7 @@ menu:
 aliases:
     - /docs/developers/large-files/
     - /store/lotus/very-large-files
-weight: 150
+weight: 125
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/payment-channels.md
+++ b/content/en/tutorials/lotus/payment-channels.md
@@ -8,7 +8,7 @@ menu:
         parent: "tutorials-lotus"
 aliases:
     - /docs/developers/payment-channels/
-weight: 160
+weight: 130
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/store-and-retrieve/retrieve-data/index.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/retrieve-data/index.md
@@ -9,7 +9,7 @@ menu:
         identifier: "tutorials-store-and-retrieve-retrieve-data"
 aliases:
     - /tutorials/store-and-retrieve/retrieve-data/
-weight: 130
+weight: 115
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -9,7 +9,7 @@ menu:
 aliases:
     - /docs/tutorials/store-and-retrieve/
     - /tutorials/store-and-retrieve/set-up/
-weight: 110
+weight: 105
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/store-and-retrieve/store-data/index.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/store-data/index.md
@@ -11,7 +11,7 @@ aliases:
     - /tutorials/store-and-retrieve/store-data/
     - /store/lotus/store-data
     - /store/slate
-weight: 120
+weight: 110
 toc: true
 ---
 


### PR DESCRIPTION
Adjusting the weights across all the pages in /Tutorials/....

Every sections add +100 in weight, while each page in a given section add +5 to leave room for additional pages in between. The first page of a section starts at x05.

This should allow the page link/button at the bottom to link to the next page in a top-to-bottom approach. The rebalancing of weight in this commit should leave the current structure intact.

- [ ] Check that the structure is intact, and that the bottom page link/button links to the next correct page across all the pages.