### PR TITLE
Removes default true to fix JS errors.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -70,8 +70,8 @@ repoHost = "GitHub"
 [options]
     lazySizes = true
     clipBoard = true
-    instantPage = true
-    flexSearch = true
+    instantPage = false
+    flexSearch = false
     darkMode = true
     bootStrapJs = true
     breadCrumb = false 


### PR DESCRIPTION
Fixes #253.

Turns out that we just needed to disable the flexSearch and instantPage options. Easy stuff.