### PR TITLE
Remove MAXIMIZE_CACHING

### DIFF
--- a/content/en/storage-providers/seal-workers/seal-workers.md
+++ b/content/en/storage-providers/seal-workers/seal-workers.md
@@ -67,7 +67,6 @@ export TMPDIR=/fast/disk/folder3                    # used when sealing
 export MINER_API_INFO:<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
 export MARKETS_API_INFO:<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
 export BELLMAN_CPU_UTILIZATION=0.875      # optimal value depends on exact hardware
-export FIL_PROOFS_MAXIMIZE_CACHING=1
 export FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1 # when GPU is available
 export FIL_PROOFS_USE_GPU_TREE_BUILDER=1   # when GPU is available
 export FIL_PROOFS_PARAMETER_CACHE=/fast/disk/folder # > 100GiB!

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -78,9 +78,6 @@ This section will cover the installation, configuration and running a Lotus seal
 1. Add the following variables to the `~/.bashrc` file and source the file. The token used for API authentication is the same as generated in the [previous tutorial]({{<relref "run-a-miner#generate-auth-token-for-seal-worker">}}). 
     
     ```shell
-    # See https://github.com/filecoin-project/rust-fil-proofs/
-    export FIL_PROOFS_MAXIMIZE_CACHING=1 # More speed at RAM cost (1x sector-size of RAM - 32 GB).
-
     # The following increases speed of PreCommit1 at the cost of using a full
     # CPU Core-Complex rather than a single core. Should be used with CPU affinities set!
     # See https://github.com/filecoin-project/rust-fil-proofs/ and the seal-workers guide.

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -179,7 +179,6 @@ This section will cover the installation, configuration, and how to start the lo
     
     ```shell
     # See https://github.com/filecoin-project/rust-fil-proofs/
-    export FIL_PROOFS_MAXIMIZE_CACHING=1 # More speed at RAM cost (1x sector-size of RAM - 32 GB).
     export FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1 # precommit2 GPU acceleration
     export FIL_PROOFS_USE_GPU_TREE_BUILDER=1
     


### PR DESCRIPTION
Removes the PROOFS_MAXIMIZE_CACHING environment variable across the different doc pages as it is not a thing anymore. https://filecoinproject.slack.com/archives/CEGB67XJ8/p1653555880864929