### PR TITLE
Audit/Revision of Operate/Disputer

### DIFF
--- a/content/en/storage-providers/operate/disputer.md
+++ b/content/en/storage-providers/operate/disputer.md
@@ -13,11 +13,11 @@ weight: 355
 toc: true
 ---
 
-[Window PoSt](https://docs.filecoin.io/reference/glossary/#window-proof-of-spacetime-windowpost) messages are necessary for ongoing maintenance of storage power. Verifying the submitted proofs is expensive, and when the gas base fee rises due to congestion, these messages become even more costly. For miners with mostly empty partitions, this cost can exceed their expected rewards from maintaining power. We need to ensure that these messages are cheap for miners, even when specifying a very high gas fee cap.
+[Window PoSt](https://docs.filecoin.io/reference/glossary/#window-proof-of-spacetime-windowpost) messages are necessary for ongoing maintenance of storage power. Verifying the submitted proofs is expensive, and when the gas base fee rises due to congestion, these messages become even more costly. For storage providers with mostly empty partitions, this cost can exceed their expected rewards from maintaining power. We need to ensure that these messages are cheap for miners, even when specifying a very high gas fee cap.
 
-The Filecoin Improvement Proposal 0010 (FIP0010) allows miners to _optimistically_ accept Window Proof of Spacetime proofs (Windows PoSt) on-chain without verification, allowing them to be disputed later by off-chain verifiers. Any Lotus node may dispute any on-chain storage proofs submitted in the past 1800 epochs (~15h) by invoking `DisputeWindowedPoSt`.
+The Filecoin Improvement Proposal 0010 (FIP0010) allows storage providers to _optimistically_ accept Window Proof of Spacetime proofs (Windows PoSt) on-chain without verification, allowing them to be disputed later by off-chain verifiers. Any Lotus node may dispute any on-chain storage proofs submitted in the past 1800 epochs (~15h) by invoking `DisputeWindowedPoSt`.
 
-When a dispute successfully refutes an optimistically accepted Window PoSt, the miner is fined one invalid proof fee (IPF) per active sector in the partition at the moment when said miner submitted the proof, plus a flat fee of 20 FIL. All incorrectly proved sectors are marked faulty, and the address that submitted the dispute is awarded a fixed `DipsuteReward`.
+When a dispute successfully refutes an optimistically accepted Window PoSt, the storage provider is fined one invalid proof fee (IPF) per active sector in the partition at the moment when said storage provider submitted the proof, plus a flat fee of 20 FIL. All incorrectly proved sectors are marked faulty, and the address that submitted the dispute is awarded a fixed `DipsuteReward`.
 
 ## Penalties and rewards
 
@@ -60,7 +60,7 @@ You can run the disputer by using the `chain disputer` command within Lotus. The
 
    You can safely ignore any stream errors when exiting the disputer.
 
-## Manual dispute
+### Manual dispute
 
 You can manually send a specific dispute message using the `dispute` command. This feature has a very narrow use-case and is for advanced users only. To perform a manual dispute run `lotus chain disputer dispute [minerAddress] [index] [postIndex]`, where:
 


### PR DESCRIPTION
Audit/Revision of the Operate/Disputer page.

Ran through all the commands listed. There does not seem to be anything missing when comparing the commands to what is currently on the v1.16.0-pre-rc tag.