### PR TITLE
edited the 'lead' metadata to be more succint, less redundant

### DIFF
--- a/content/en/tutorials/lotus/store-and-retrieve/retrieve-data/index.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/retrieve-data/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieve data"
 description: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
-lead: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
+lead: Introduction to setting up, storing, and retrieving using the Filecoin network
 draft: false
 menu:
     tutorials:

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -1,7 +1,7 @@
 ---
 title: "Set up"
 description: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
-lead: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
+lead: Setting up, storing, and retrieving using the Filecoin network
 draft: false
 menu:
     tutorials:
@@ -233,4 +233,3 @@ It is incredibly important that you backup your addreses. Storing a copy of your
     This will create a new file called `my_address.key` in the current directory.
 
 Once you have your address in a file, you can copy it to another drive, securely send it to another computer, or even print it out. It's important to keep this file safe. If anything happens to your Lotus node, you can still access your funds using this file.
-

--- a/content/en/tutorials/lotus/store-and-retrieve/store-data/index.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/store-data/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Store data"
 description: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
-lead: "The process of storing and retrieving data using the Filecoin network is slightly different from how most storage platforms work. This tutorial walks you through the whole end-to-end process of keeping your data and then getting it back when you need it! This tutorial should take you about an hour to complete."
+lead: Introduction to setting up, storing, and retrieving using the Filecoin network
 draft: false
 menu:
     tutorials:
@@ -252,7 +252,7 @@ Once the data has been sent to the storage clients, the storage deals can take u
     Sending Channels
     ID                   Status   Sending To   Root Cid     Initiated?  Transferred  Voucher
     1620782601911586915  Ongoing  ...KPFTTwY7  ...zyd3kapm  Y           224.1MiB     ...bqhcidjmajbelhlxfqry3d7qlu3tvar45a"}}
-    
+
     Receiving Channels
     ...
     ```
@@ -327,4 +327,3 @@ The following deal states are informational, and do not mean that a deal has fai
 | StorageDealWaitingForData | Either a manual transfer is occurring, or the storage provider has not received a data-transfer request from the client. |
 
 These states come from the [Lotus project GitHub repository](https://github.com/filecoin-project/go-fil-markets/blob/master/storagemarket/dealstatus.go).
-


### PR DESCRIPTION
There was a redundant lead paragraph at the beginning of the 'set up', 'store data' and 'retrieve data' pieces of this tutorial, so I made it more succint, and applicable to all three of these sections