### PR TITLE
Hide "copy" button for output, fix "Benchmarks" render error

### DIFF
--- a/assets/js/clipboard.js
+++ b/assets/js/clipboard.js
@@ -6,8 +6,7 @@ for (var i = 0; i < pre.length; ++ i)
 {
   var element = pre[i];
   var mermaid = element.getElementsByClassName('language-mermaid')[0];
-
-  if (mermaid == null) {
+  if (mermaid == null && pre[i].innerText.indexOf("Output:") < 0) {
     element.insertAdjacentHTML('afterbegin', '<button class="btn btn-copy"></button>');
   }
 }

--- a/content/en/storage-providers/operate/benchmarks.md
+++ b/content/en/storage-providers/operate/benchmarks.md
@@ -77,6 +77,9 @@ Use the self-documenting feature of the tool to explore the different commands.
 
 This will output something like:
 
+```
+Output:
+
 NAME:
    lotus-bench - Benchmark performance of lotus on your hardware
 


### PR DESCRIPTION
Resolves #227 

Sadly, the "with-output" class being specified in the markdown isn't propagating to the HTML. However, we can hide "copy" buttons for blocks that have "Output:" clearly labeled, as demonstrated. 