### PR TITLE
Resolve fenced code block indentation issue

### DIFF
--- a/content/en/storage-providers/seal-workers/seal-workers.md
+++ b/content/en/storage-providers/seal-workers/seal-workers.md
@@ -179,7 +179,6 @@ Without storage groups, PC2 tasks on Workers 1 or 2 could be scheduled with sect
     ```
 
 - Worker 2 (PC1, PC2):
-
     ```json
     {        
       "ID": "b5db38b9-2d2e-06eb-8367-7338e1bcd0f1",
@@ -193,7 +192,7 @@ Without storage groups, PC2 tasks on Workers 1 or 2 could be scheduled with sect
     ```
 
 - Worker 3 (PC1):
-```json
+    ```json
     {        
       "ID": "423e45b7-e8e6-64b5-9a62-eb45929d9562", 
       "Weight": 10,


### PR DESCRIPTION
Incorrect indentation on opening code block fence on `seal-workers.md` line 196 (under "- Worker 3 (PC1):") caused the block not to be closed until line 220 (against GitHub renderer and Hugo). Resolved by indenting to align with bullet point block. Also deleted a blank line to make the code style more consistent.