### PR TITLE
Fix --halt-after-import order error

### DIFF
--- a/content/en/lotus/manage/chain-management.md
+++ b/content/en/lotus/manage/chain-management.md
@@ -175,7 +175,7 @@ lotus daemon --import-chain <filename>
 If you do not want the daemon to start once the snapshot has finished, add the `--halt-after-import` flag:
 
 ```shell
-lotus daemon --import-snapshot --halt-after-import <filename>
+lotus daemon --halt-after-import --import-snapshot <filename>
 ```
 
 ## Compacting the chain data


### PR DESCRIPTION
When --halt-after-import after --import-snapshot, there will be error says: Not found file --halt-after-import, but when --halt-after-import is ahead --import-snapshot, like lotus daemon --halt-after-import --import-snapshot <filename>, it'll work fine