### PR TITLE
Adds 404 tracking code and logic for Plausible.io

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -7,4 +7,5 @@
     </article>
   </div>
 </div>
+<script>plausible("404",{ props: { path: document.location.pathname } });</script>
 {{ end }}

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -12,3 +12,4 @@
   gtag('config', 'G-ELCLJ7LF8Y');
 </script>
 <script defer data-domain="lotus.filecoin.io" src="https://plausible.io/js/plausible.js"></script>
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>

--- a/static/ipfs-404.html
+++ b/static/ipfs-404.html
@@ -7,4 +7,5 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
     <meta http-equiv="refresh" content="0; url=https://lotus.filecoin.io/"/>
   </head>
+  <script>plausible("404",{ props: { path: document.location.pathname } });</script>
 </html>


### PR DESCRIPTION
Plausible.io can track inbound 404 pages, but we need to configure the Lotus docs site a teeny bit before we can view the data. This PR adds a couple of new script tags, one into the head of every page, and another into 404 pages.