### PR TITLE
1.17.0 docs/tutorial changes. 

### DIFF
--- a/content/en/developers/local-network.md
+++ b/content/en/developers/local-network.md
@@ -173,9 +173,12 @@ Local-nets use slightly different binaries to those used in the Filecoin mainnet
 3. Checkout to the latest branch:
 
    ```shell
+   git checkout releases
+   # 'releases' always checks out the latest stable release
+   # if you need a specific release use 
    git checkout <tag_or_release>
    # For example:
-   git checkout <vX.X.X> # tag for a release
+   git checkout v1.17.0 # tag for a release
    ```
 
 4. Remove any existing repositories.

--- a/content/en/kb/depreciated-features/index.md
+++ b/content/en/kb/depreciated-features/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Mark for upgrade is deprecated"
-description: "Marking sectors for upgrade has been depreciated as of Lotus v1.15.0"
+description: "Marking sectors for upgrade has been deprecated as of Lotus v1.15.0"
 date: 2022-03-17T12:00:35+01:00
 lastmod: 2021-11-16T12:00:35+01:00
 draft: false

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -14,7 +14,7 @@ The following instructions are specific to Linux installations.
 There are several ways to install Lotus on Linux:
 
 + [Snap package manager](#snap-package-manager)
-+ [AppImages](#appimage)
++ [AppImage](#appimage)
 + [Building from source](#building-from-source).
 
 {{< alert icon="warning">}}**Storage providers should build from source**.
@@ -42,7 +42,7 @@ You can find out more about this Snap [over at Snapcraft.io](https://snapcraft.i
 
 [AppImages](https://appimage.org/) are portable applications that allow developers to package software and dependencies in a single executable. AppImages run on most Linux-based operating systems.
 
-1. Go to the latest [releases page in the Lotus GitHub repository](https://github.com/filecoin-project/lotus/releases/tag/v1.13.0).
+1. Go to the latest [releases page in the Lotus GitHub repository](https://github.com/filecoin-project/lotus/releases/latest).
 1. Under **Assets**, download the AppImage.
 1. Open a terminal window and move to the location where you downloaded the AppImage. This location is likely your **Downloads** folder:
 
@@ -53,13 +53,13 @@ You can find out more about this Snap [over at Snapcraft.io](https://snapcraft.i
 1. Make the AppImage executable:
 
     ```shell
-    chmod +x lotus_v1.13.0_linux-amd64.appimage
+    chmod +x ./Lotus-v1.17.0-x86_64.AppImage
     ```
 
-1. You can now run the AppImage file by double-clicking on it or opening it from a terminal window:
+1. Move the `AppImage` to `/usr/local/bin` and rename it `lotus`:
 
     ```shell
-    ./lotus-v1.13.0_linx-amd64.appimage
+    sudo mv Lotus-v1.17.0-x86_64.AppImage /usr/local/bin/lotus
     ```
 
 ## Building from source
@@ -198,7 +198,7 @@ Once all the dependencies are installed, you can build and install Lotus.
    lotus --version
    ```
    ```
-   lotus version 1.13.0+calibnet+git.7a55e8e89
+   lotus version 1.17.0+mainnet+git.e120c9eaf
    ```
 
 1. You should now have Lotus installed. You can now [start the Lotus daemon](#start-the-lotus-daemon-and-sync-the-chain).
@@ -307,6 +307,7 @@ Or use `lotus net` to check the number of other peers that it is connected to in
 ```shell
 lotus net peers
 ```
+
 ```
 12D3KooWSDqWSDNZtpJae15FBGpJLeLmyabUfZmWDWEjqEGtUF8N, [/ip4/58.144.221.27/tcp/33425]
 12D3KooWRTQoDUhWVZH9z5u9XmaFDvFw14YkcW7dSBFJ8CuzDHnu, [/ip4/67.212.85.202/tcp/10906]
@@ -317,10 +318,11 @@ Or check the current version of your Lotus node as well as network.
 ```shell
 lotus version
 ```
+
 ```
-Daemon:  1.13.0+calibnet+git.7a55e8e89+api1.4.0
-Local: lotus version 1.13.0+calibnet+git.7a55e8e89
-# running lotus v1.13.0 on Calibration testnet
+Daemon:  1.17.0+mainnet+git.e120c9eaf+api1.5.0
+Local: lotus version 1.17.0+mainnet+git.e120c9eaf
+# running lotus v1.17.0 on Main net
 ```
 
 ## Stop the Lotus daemon

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -25,7 +25,7 @@ Before we get started, let's just go over the terms we'll use in this guide:
 To spin up a Lotus lite-node, you will need:
 
 1. A Lotus node - For best results, make sure that this node is fully synced.
-2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.16.4 or higher installed.
+2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.17.9 or higher installed.
 3. You must have all the software dependencies required to build Lotus.
 
 ## Full-node preparation
@@ -87,7 +87,7 @@ You need to create the Lotus executable to run your lite-node with. This process
 
 1. Move onto [starting the lite-node](#start-the-lite-node).
 
-### M1-based Macs
+### M1-based Macs <!--STEF update-->
 
 Because of the novel architecture of the M1-based Mac computers, some specific environment variables must be set before creating the `lotus` executable.
 

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -40,7 +40,7 @@ If you are using a node-hosting service like [Glif](https://www.glif.io/) or [In
 
 1. On your full-node open `~/.lotus/config` and:
 
-    a. Uncommend line 3.
+    a. Uncomment line 3.
     a. Change `127.0.0.1` to `0.0.0.0`.
 
     ```toml
@@ -87,7 +87,7 @@ You need to create the Lotus executable to run your lite-node with. This process
 
 1. Move onto [starting the lite-node](#start-the-lite-node).
 
-### M1-based Macs <!--STEF update-->
+### M1-based Macs 
 
 Because of the novel architecture of the M1-based Mac computers, some specific environment variables must be set before creating the `lotus` executable.
 

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -272,9 +272,9 @@ lotus version
 ```
 
 ```plaintext
-Daemon:  1.13.0+calibnet+git.7a55e8e89+api1.4.0
-Local: lotus version 1.13.0+calibnet+git.7a55e8e89
-# running lotus v1.13.0 on Calibration testnet
+Daemon:  1.17.0+mainnet+git.e120c9eaf+api1.5.0
+Local: lotus version 1.17.0+mainnet+git.e120c9eaf
+# running lotus v1.17.0 on Calibration testnet
 ```
 
 ## Stop the Lotus daemon

--- a/content/en/lotus/manage/lotus-cli.md
+++ b/content/en/lotus/manage/lotus-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI"
 description: "Reference documentation for the Lotus command-line interface."
-lead: "Reference documentation for the Lotus command-line interface. This documentation was automatically generated using Lotus v1.15.1."
+lead: "Reference documentation for the Lotus command-line interface. This documentation was automatically generated using Lotus v1.17.0."
 draft: false
 menu:
     lotus:
@@ -12,9 +12,10 @@ weight: 440
 toc: true
 ---
 
-<!-- This page was copied from https://github.com/filecoin-project/lotus/blob/release/v1.15.1/documentation/en/cli-lotus.md -->
+<!-- This page was copied from https://github.com/filecoin-project/lotus/blob/release/v1.17.0/documentation/en/cli-lotus.md -->
 
 # lotus
+
 ```
 NAME:
    lotus - Filecoin decentralized storage network client
@@ -23,7 +24,7 @@ USAGE:
    lotus [global options] command [command options] [arguments...]
 
 VERSION:
-   1.15.1-rc3
+   1.17.0
 
 COMMANDS:
    daemon   Start a lotus daemon process
@@ -53,11 +54,12 @@ COMMANDS:
      status  Check node status
 
 GLOBAL OPTIONS:
-   --interactive  setting to false will disable interactive functionality of commands (default: false)
    --force-send   if true, will ignore pre-send checks (default: false)
-   --vv           enables very verbose mode, useful for debugging the CLI (default: false)
    --help, -h     show help (default: false)
+   --interactive  setting to false will disable interactive functionality of commands (default: false)
    --version, -v  print the version (default: false)
+   --vv           enables very verbose mode, useful for debugging the CLI (default: false)
+   
 ```
 
 ## lotus daemon
@@ -121,8 +123,7 @@ DESCRIPTION:
    this command must be within this base path
 
 OPTIONS:
-   --offline   create backup without the node running (default: false)
-   --help, -h  show help (default: false)
+   --offline  create backup without the node running (default: false)
    
 ```
 
@@ -154,7 +155,6 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -168,7 +168,6 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -197,16 +196,15 @@ CATEGORY:
    BASIC
 
 OPTIONS:
+   --force              Deprecated: use global 'force-send' (default: false)
    --from value         optionally specify the account to send funds from
-   --gas-premium value  specify gas price to use in AttoFIL (default: "0")
    --gas-feecap value   specify gas fee cap to use in AttoFIL (default: "0")
    --gas-limit value    specify gas limit (default: 0)
-   --nonce value        specify the nonce to use (default: 0)
+   --gas-premium value  specify gas price to use in AttoFIL (default: "0")
    --method value       specify method to invoke (default: 0)
-   --params-json value  specify invocation parameters in json
+   --nonce value        specify the nonce to use (default: 0)
    --params-hex value   specify invocation parameters in hex
-   --force              Deprecated: use global 'force-send' (default: false)
-   --help, -h           show help (default: false)
+   --params-json value  specify invocation parameters in json
    
 ```
 
@@ -228,7 +226,7 @@ COMMANDS:
    set-default  Set default wallet address
    sign         sign a message
    verify       verify the signature of a message
-   delete       Delete an account from the wallet
+   delete       Soft delete an address from the wallet - hard deletion needed for permanent removal
    market       Interact with market balances
    help, h      Shows a list of commands or help for one command
 
@@ -262,7 +260,6 @@ OPTIONS:
    --addr-only, -a  Only print addresses (default: false)
    --id, -i         Output ID addresses (default: false)
    --market, -m     Output market balances (default: false)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -301,9 +298,8 @@ USAGE:
    lotus wallet import [command options] [<path> (optional, will read from stdin if omitted)]
 
 OPTIONS:
-   --format value  specify input format for key (default: "hex-lotus")
    --as-default    import the given key as your new default key (default: false)
-   --help, -h      show help (default: false)
+   --format value  specify input format for key (default: "hex-lotus")
    
 ```
 
@@ -362,7 +358,7 @@ OPTIONS:
 ### lotus wallet delete
 ```
 NAME:
-   lotus wallet delete - Delete an account from the wallet
+   lotus wallet delete - Soft delete an address from the wallet - hard deletion needed for permanent removal
 
 USAGE:
    lotus wallet delete [command options] <address> 
@@ -399,10 +395,9 @@ USAGE:
    lotus wallet market withdraw [command options] [amount (FIL) optional, otherwise will withdraw max available]
 
 OPTIONS:
-   --wallet value, -w value   Specify address to withdraw funds to, otherwise it will use the default wallet address
    --address value, -a value  Market address to withdraw from (account or miner actor address, defaults to --wallet address)
    --confidence value         number of block confirmations to wait for (default: 5)
-   --help, -h                 show help (default: false)
+   --wallet value, -w value   Specify address to withdraw funds to, otherwise it will use the default wallet address
    
 ```
 
@@ -415,9 +410,8 @@ USAGE:
    lotus wallet market add [command options] <amount>
 
 OPTIONS:
-   --from value, -f value     Specify address to move funds from, otherwise it will use the default wallet address
    --address value, -a value  Market address to move funds to (account or miner actor address, defaults to --from address)
-   --help, -h                 show help (default: false)
+   --from value, -f value     Specify address to move funds from, otherwise it will use the default wallet address
    
 ```
 
@@ -479,7 +473,6 @@ CATEGORY:
 OPTIONS:
    --car        import from a car file instead of a regular file (default: false)
    --quiet, -q  Output root CID only (default: false)
-   --help, -h   show help (default: false)
    
 ```
 
@@ -511,7 +504,6 @@ CATEGORY:
    DATA
 
 OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 
@@ -544,7 +536,6 @@ CATEGORY:
 
 OPTIONS:
    --pieceCid value  require data to be retrieved from a specific Piece CID
-   --help, -h        show help (default: false)
    
 ```
 
@@ -561,7 +552,6 @@ CATEGORY:
 
 OPTIONS:
    --size value  data size in bytes (default: 0)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -610,15 +600,14 @@ DESCRIPTION:
      $ lotus client retrieve --data-selector /Links/0/Hash Qm... my-file.txt
 
 OPTIONS:
+   --allow-local                                           (default: false)
    --car                                                   Export to a car file instead of a regular file (default: false)
-   --data-selector value, --datamodel-path-selector value  IPLD datamodel text-path selector, or IPLD json selector
    --car-export-merkle-proof                               (requires --data-selector and --car) Export data-selector merkle proof (default: false)
+   --data-selector value, --datamodel-path-selector value  IPLD datamodel text-path selector, or IPLD json selector
    --from value                                            address to send transactions from
-   --provider value, --miner value                         provider to use for retrieval, if not present it'll use local discovery
    --maxPrice value                                        maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                                        require data to be retrieved from a specific Piece CID
-   --allow-local                                           (default: false)
-   --help, -h                                              show help (default: false)
+   --provider value, --miner value                         provider to use for retrieval, if not present it'll use local discovery
    
 ```
 
@@ -634,14 +623,13 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --ipld                           list IPLD datamodel links (default: false)
+   --allow-local                    (default: false)
    --data-selector value            IPLD datamodel text-path selector, or IPLD json selector
    --from value                     address to send transactions from
-   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
+   --ipld                           list IPLD datamodel links (default: false)
    --maxPrice value                 maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                 require data to be retrieved from a specific Piece CID
-   --allow-local                    (default: false)
-   --help, -h                       show help (default: false)
+   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
    
 ```
 
@@ -657,15 +645,14 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --ipld                           list IPLD datamodel links (default: false)
-   --depth value                    list links recursively up to the specified depth (default: 1)
+   --allow-local                    (default: false)
    --data-selector value            IPLD datamodel text-path selector, or IPLD json selector
+   --depth value                    list links recursively up to the specified depth (default: 1)
    --from value                     address to send transactions from
-   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
+   --ipld                           list IPLD datamodel links (default: false)
    --maxPrice value                 maximum price the client is willing to consider (default: 0 FIL)
    --pieceCid value                 require data to be retrieved from a specific Piece CID
-   --allow-local                    (default: false)
-   --help, -h                       show help (default: false)
+   --provider value, --miner value  provider to use for retrieval, if not present it'll use local discovery
    
 ```
 
@@ -682,7 +669,6 @@ CATEGORY:
 
 OPTIONS:
    --deal-id value  specify retrieval deal by deal ID (default: 0)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -698,12 +684,11 @@ CATEGORY:
    RETRIEVAL
 
 OPTIONS:
-   --verbose, -v  print verbose deal details (default: false)
    --color        use color in display output (default: depends on output being a TTY)
-   --show-failed  show failed/failing deals (default: true)
    --completed    show completed retrievals (default: false)
+   --show-failed  show failed/failing deals (default: true)
+   --verbose, -v  print verbose deal details (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -729,15 +714,14 @@ DESCRIPTION:
    The minimum value is 518400 (6 months).
 
 OPTIONS:
+   --fast-retrieval             indicates that data should be available for fast retrieval (default: true)
+   --from value                 specify address to fund the deal with
    --manual-piece-cid value     manually specify piece commitment for data (dataCid must be to a car file)
    --manual-piece-size value    if manually specifying piece cid, used to specify size (dataCid must be to a car file) (default: 0)
    --manual-stateless-deal      instructs the node to send an offline deal without registering it with the deallist/fsm (default: false)
-   --from value                 specify address to fund the deal with
-   --start-epoch value          specify the epoch that the deal should start at (default: -1)
-   --fast-retrieval             indicates that data should be available for fast retrieval (default: true)
-   --verified-deal              indicate that the deal counts towards verified client total (default: true if client is verified, false otherwise)
    --provider-collateral value  specify the requested provider collateral the miner should put up
-   --help, -h                   show help (default: false)
+   --start-epoch value          specify the epoch that the deal should start at (default: -1)
+   --verified-deal              indicate that the deal counts towards verified client total (default: true if client is verified, false otherwise)
    
 ```
 
@@ -753,10 +737,9 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
+   --duration value  deal duration (default: 0)
    --peerid value    specify peer ID of node to make query against
    --size value      data size in bytes (default: 0)
-   --duration value  deal duration (default: 0)
-   --help, -h        show help (default: false)
    
 ```
 
@@ -772,11 +755,10 @@ CATEGORY:
    STORAGE
 
 OPTIONS:
-   --verbose, -v  print verbose deal details (default: false)
    --color        use color in display output (default: depends on output being a TTY)
    --show-failed  show failed/failing deals (default: false)
+   --verbose, -v  print verbose deal details (default: false)
    --watch        watch deal updates in real-time, rather than a one time list (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -786,7 +768,7 @@ NAME:
    lotus client get-deal - Print detailed deal information
 
 USAGE:
-   lotus client get-deal [command options] [arguments...]
+   lotus client get-deal [command options] [proposalCID]
 
 CATEGORY:
    STORAGE
@@ -810,7 +792,7 @@ CATEGORY:
 OPTIONS:
    --by-ping              sort by ping (default: false)
    --output-format value  Either 'text' or 'csv' (default: "text")
-   --help, -h             show help (default: false)
+   --protocols            Output supported deal protocols (default: false)
    
 ```
 
@@ -827,7 +809,6 @@ CATEGORY:
 
 OPTIONS:
    --newer-than value  (default: 0s)
-   --help, -h          show help (default: false)
    
 ```
 
@@ -845,7 +826,6 @@ CATEGORY:
 OPTIONS:
    --deal-id value       (default: 0)
    --proposal-cid value  
-   --help, -h            show help (default: false)
    
 ```
 
@@ -861,7 +841,6 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 
@@ -894,7 +873,6 @@ CATEGORY:
 
 OPTIONS:
    --client value  specify storage client address
-   --help, -h      show help (default: false)
    
 ```
 
@@ -910,12 +888,11 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --verbose, -v  print verbose transfer details (default: false)
    --color        use color in display output (default: depends on output being a TTY)
    --completed    show completed data transfers (default: false)
-   --watch        watch deal updates in real-time, rather than a one time list (default: false)
    --show-failed  show failed/cancelled transfers (default: false)
-   --help, -h     show help (default: false)
+   --verbose, -v  print verbose transfer details (default: false)
+   --watch        watch deal updates in real-time, rather than a one time list (default: false)
    
 ```
 
@@ -931,9 +908,8 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --peerid value  narrow to transfer with specific peer
    --initiator     specify only transfers where peer is/is not initiator (default: true)
-   --help, -h      show help (default: false)
+   --peerid value  narrow to transfer with specific peer
    
 ```
 
@@ -949,10 +925,9 @@ CATEGORY:
    UTIL
 
 OPTIONS:
-   --peerid value          narrow to transfer with specific peer
-   --initiator             specify only transfers where peer is/is not initiator (default: true)
    --cancel-timeout value  time to wait for cancel to be sent to storage provider (default: 5s)
-   --help, -h              show help (default: false)
+   --initiator             specify only transfers where peer is/is not initiator (default: true)
+   --peerid value          narrow to transfer with specific peer
    
 ```
 
@@ -999,11 +974,10 @@ USAGE:
    lotus msig create [command options] [address1 address2 ...]
 
 OPTIONS:
-   --required value  number of required approvals (uses number of signers provided if omitted) (default: 0)
-   --value value     initial funds to give to multisig (default: "0")
    --duration value  length of the period over which funds unlock (default: "0")
    --from value      account to send the create message from
-   --help, -h        show help (default: false)
+   --required value  number of required approvals (uses number of signers provided if omitted) (default: 0)
+   --value value     initial funds to give to multisig (default: "0")
    
 ```
 
@@ -1016,9 +990,8 @@ USAGE:
    lotus msig inspect [command options] [address]
 
 OPTIONS:
-   --vesting        Include vesting details (default: false)
    --decode-params  Decode parameters of transaction proposals (default: false)
-   --help, -h       show help (default: false)
+   --vesting        Include vesting details (default: false)
    
 ```
 
@@ -1032,7 +1005,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the propose message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1047,7 +1019,6 @@ USAGE:
 OPTIONS:
    --decrease-threshold  whether the number of required signers should be decreased (default: false)
    --from value          account to send the propose message from
-   --help, -h            show help (default: false)
    
 ```
 
@@ -1061,7 +1032,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1075,7 +1045,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the cancel message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1088,9 +1057,8 @@ USAGE:
    lotus msig add-propose [command options] [multisigAddress signer]
 
 OPTIONS:
-   --increase-threshold  whether the number of required signers should be increased (default: false)
    --from value          account to send the propose message from
-   --help, -h            show help (default: false)
+   --increase-threshold  whether the number of required signers should be increased (default: false)
    
 ```
 
@@ -1104,7 +1072,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1118,7 +1085,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1132,7 +1098,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1146,7 +1111,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1160,7 +1124,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1174,7 +1137,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the propose message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1188,7 +1150,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the approve message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1202,7 +1163,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the cancel message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1215,9 +1175,8 @@ USAGE:
    lotus msig vested [command options] [multisigAddress]
 
 OPTIONS:
-   --start-epoch value  start epoch to measure vesting from (default: 0)
    --end-epoch value    end epoch to stop measure vesting at (default: -1)
-   --help, -h           show help (default: false)
+   --start-epoch value  start epoch to measure vesting from (default: 0)
    
 ```
 
@@ -1231,7 +1190,6 @@ USAGE:
 
 OPTIONS:
    --from value  account to send the proposal from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1267,7 +1225,6 @@ USAGE:
 
 OPTIONS:
    --from value  specify your notary address to send the message from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1333,7 +1290,6 @@ USAGE:
 
 OPTIONS:
    --id value  specify the RemoveDataCapProposal ID (will look up on chain if unspecified) (default: 0)
-   --help, -h  show help (default: false)
    
 ```
 
@@ -1369,9 +1325,8 @@ USAGE:
    lotus paych add-funds [command options] [fromAddress toAddress amount]
 
 OPTIONS:
-   --restart-retrievals  restart stalled retrieval deals on this payment channel (default: true)
    --reserve             mark funds as reserved (default: false)
-   --help, -h            show help (default: false)
+   --restart-retrievals  restart stalled retrieval deals on this payment channel (default: true)
    
 ```
 
@@ -1420,7 +1375,6 @@ USAGE:
 
 OPTIONS:
    --lane value  specify payment channel lane to use (default: 0)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1459,8 +1413,7 @@ USAGE:
    lotus paych voucher list [command options] [channelAddress]
 
 OPTIONS:
-   --export    Print voucher as serialized string (default: false)
-   --help, -h  show help (default: false)
+   --export  Print voucher as serialized string (default: false)
    
 ```
 
@@ -1473,8 +1426,7 @@ USAGE:
    lotus paych voucher best-spendable [command options] [channelAddress]
 
 OPTIONS:
-   --export    Print voucher as serialized string (default: false)
-   --help, -h  show help (default: false)
+   --export  Print voucher as serialized string (default: false)
    
 ```
 
@@ -1571,7 +1523,6 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1585,7 +1536,6 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   --help, -h    show help (default: false)
    
 ```
 
@@ -1622,11 +1572,10 @@ USAGE:
    lotus mpool pending [command options] [arguments...]
 
 OPTIONS:
-   --local       print pending messages for addresses in local wallet only (default: false)
    --cids        only print cids of messages in output (default: false)
-   --to value    return messages to a given address
    --from value  return messages from a given address
-   --help, -h    show help (default: false)
+   --local       print pending messages for addresses in local wallet only (default: false)
+   --to value    return messages to a given address
    
 ```
 
@@ -1652,9 +1601,8 @@ USAGE:
    lotus mpool stat [command options] [arguments...]
 
 OPTIONS:
-   --local                   print stats for addresses in local wallet only (default: false)
    --basefee-lookback value  number of blocks to look back for minimum basefee (default: 60)
-   --help, -h                show help (default: false)
+   --local                   print stats for addresses in local wallet only (default: false)
    
 ```
 
@@ -1667,12 +1615,11 @@ USAGE:
    lotus mpool replace [command options] <from> <nonce> | <message-cid>
 
 OPTIONS:
-   --gas-feecap value   gas feecap for new message (burn and pay to miner, attoFIL/GasUnit)
-   --gas-premium value  gas price for new message (pay to miner, attoFIL/GasUnit)
-   --gas-limit value    gas limit for new message (GasUnit) (default: 0)
    --auto               automatically reprice the specified message (default: false)
    --fee-limit max-fee  Spend up to X FIL for this message in units of FIL. Previously when flag was max-fee units were in attoFIL. Applicable for auto mode
-   --help, -h           show help (default: false)
+   --gas-feecap value   gas feecap for new message (burn and pay to miner, attoFIL/GasUnit)
+   --gas-limit value    gas limit for new message (GasUnit) (default: 0)
+   --gas-premium value  gas price for new message (pay to miner, attoFIL/GasUnit)
    
 ```
 
@@ -1686,9 +1633,8 @@ USAGE:
 
 OPTIONS:
    --from value    search for messages with given 'from' address
-   --to value      search for messages with given 'to' address
    --method value  search for messages with given method (default: 0)
-   --help, -h      show help (default: false)
+   --to value      search for messages with given 'to' address
    
 ```
 
@@ -1714,8 +1660,7 @@ USAGE:
    lotus mpool gas-perf [command options] [arguments...]
 
 OPTIONS:
-   --all       print gas performance for all mempool messages (default only prints for local) (default: false)
-   --help, -h  show help (default: false)
+   --all  print gas performance for all mempool messages (default only prints for local) (default: false)
    
 ```
 
@@ -1741,30 +1686,31 @@ USAGE:
    lotus state command [command options] [arguments...]
 
 COMMANDS:
-   power                   Query network or miner power
-   sectors                 Query the sector set of a miner
-   active-sectors          Query the active sector set of a miner
-   list-actors             list all actors in the network
-   list-miners             list all miners in the network
-   circulating-supply      Get the exact current circulating supply of Filecoin
-   sector                  Get miner sector info
-   get-actor               Print actor information
-   lookup                  Find corresponding ID address
-   replay                  Replay a particular message
-   sector-size             Look up miners sector size
-   read-state              View a json representation of an actors state
-   list-messages           list messages on chain matching given criteria
-   compute-state           Perform state computations
-   call                    Invoke a method on an actor locally
-   get-deal                View on-chain deal info
-   wait-msg                Wait for a message to appear on chain
-   search-msg              Search to see whether a message has appeared on chain
-   miner-info              Retrieve miner information
-   market                  Inspect the storage market actor
-   exec-trace              Get the execution trace of a given message
-   network-version         Returns the network version
-   miner-proving-deadline  Retrieve information about a given miner's proving deadline
-   help, h                 Shows a list of commands or help for one command
+   power                       Query network or miner power
+   sectors                     Query the sector set of a miner
+   active-sectors              Query the active sector set of a miner
+   list-actors                 list all actors in the network
+   list-miners                 list all miners in the network
+   circulating-supply          Get the exact current circulating supply of Filecoin
+   sector, sector-info         Get miner sector info
+   get-actor                   Print actor information
+   lookup                      Find corresponding ID address
+   replay                      Replay a particular message
+   sector-size                 Look up miners sector size
+   read-state                  View a json representation of an actors state
+   list-messages               list messages on chain matching given criteria
+   compute-state               Perform state computations
+   call                        Invoke a method on an actor locally
+   get-deal                    View on-chain deal info
+   wait-msg, wait-message      Wait for a message to appear on chain
+   search-msg, search-message  Search to see whether a message has appeared on chain
+   miner-info                  Retrieve miner information
+   market                      Inspect the storage market actor
+   exec-trace                  Get the execution trace of a given message
+   network-version             Returns the network version
+   miner-proving-deadline      Retrieve information about a given miner's proving deadline
+   actor-cids                  Returns the built-in actor bundle manifest ID & system actor cids
+   help, h                     Shows a list of commands or help for one command
 
 OPTIONS:
    --tipset value  specify tipset to call method on (pass comma separated array of cids)
@@ -1834,7 +1780,6 @@ USAGE:
 
 OPTIONS:
    --sort-by value  criteria to sort miners by (none, num-deals)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -1848,21 +1793,11 @@ USAGE:
 
 OPTIONS:
    --vm-supply  calculates the approximation of the circulating supply used internally by the VM (instead of the exact amount) (default: false)
-   --help, -h   show help (default: false)
    
 ```
 
-### lotus state sector
+#### lotus state sector, sector-info
 ```
-NAME:
-   lotus state sector - Get miner sector info
-
-USAGE:
-   lotus state sector [command options] [minerAddress] [sectorNumber]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
 ```
 
 ### lotus state get-actor
@@ -1888,7 +1823,6 @@ USAGE:
 
 OPTIONS:
    --reverse, -r  Perform reverse lookup (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -1901,9 +1835,8 @@ USAGE:
    lotus state replay [command options] <messageCid>
 
 OPTIONS:
-   --show-trace    print out full execution trace for given message (default: false)
    --detailed-gas  print out detailed gas costs for given message (default: false)
-   --help, -h      show help (default: false)
+   --show-trace    print out full execution trace for given message (default: false)
    
 ```
 
@@ -1942,11 +1875,10 @@ USAGE:
    lotus state list-messages [command options] [arguments...]
 
 OPTIONS:
-   --to value        return messages to a given address
-   --from value      return messages from a given address
-   --toheight value  don't look before given block height (default: 0)
    --cids            print message CIDs instead of messages (default: false)
-   --help, -h        show help (default: false)
+   --from value      return messages from a given address
+   --to value        return messages to a given address
+   --toheight value  don't look before given block height (default: 0)
    
 ```
 
@@ -1959,14 +1891,13 @@ USAGE:
    lotus state compute-state [command options] [arguments...]
 
 OPTIONS:
-   --vm-height value             set the height that the vm will see (default: 0)
    --apply-mpool-messages        apply messages from the mempool to the computed state (default: false)
-   --show-trace                  print out full execution trace for given tipset (default: false)
+   --compute-state-output value  a json file containing pre-existing compute-state output, to generate html reports without rerunning state changes
    --html                        generate html report (default: false)
    --json                        generate json output (default: false)
-   --compute-state-output value  a json file containing pre-existing compute-state output, to generate html reports without rerunning state changes
    --no-timing                   don't show timing information in html traces (default: false)
-   --help, -h                    show help (default: false)
+   --show-trace                  print out full execution trace for given tipset (default: false)
+   --vm-height value             set the height that the vm will see (default: 0)
    
 ```
 
@@ -1979,11 +1910,10 @@ USAGE:
    lotus state call [command options] [toAddress methodId params (optional)]
 
 OPTIONS:
-   --from value      (default: "f00")
-   --value value     specify value field for invocation (default: "0")
-   --ret value       specify how to parse output (raw, decoded, base64, hex) (default: "decoded")
    --encoding value  specify params encoding to parse (base64, hex) (default: "base64")
-   --help, -h        show help (default: false)
+   --from value      (default: "f00")
+   --ret value       specify how to parse output (raw, decoded, base64, hex) (default: "decoded")
+   --value value     specify value field for invocation (default: "0")
    
 ```
 
@@ -2000,31 +1930,12 @@ OPTIONS:
    
 ```
 
-### lotus state wait-msg
+#### lotus state wait-msg, wait-message
 ```
-NAME:
-   lotus state wait-msg - Wait for a message to appear on chain
-
-USAGE:
-   lotus state wait-msg [command options] [messageCid]
-
-OPTIONS:
-   --timeout value  (default: "10m")
-   --help, -h       show help (default: false)
-   
 ```
 
-### lotus state search-msg
+#### lotus state search-msg, search-message
 ```
-NAME:
-   lotus state search-msg - Search to see whether a message has appeared on chain
-
-USAGE:
-   lotus state search-msg [command options] [messageCid]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
 ```
 
 ### lotus state miner-info
@@ -2109,6 +2020,19 @@ OPTIONS:
    
 ```
 
+### lotus state actor-cids
+```
+NAME:
+   lotus state actor-cids - Returns the built-in actor bundle manifest ID & system actor cids
+
+USAGE:
+   lotus state actor-cids [command options] [arguments...]
+
+OPTIONS:
+   --network-version value  specify network version (default: 16)
+   
+```
+
 ## lotus chain
 ```
 NAME:
@@ -2118,24 +2042,24 @@ USAGE:
    lotus chain command [command options] [arguments...]
 
 COMMANDS:
-   head             Print chain head
-   getblock         Get a block and print its details
-   read-obj         Read the raw bytes of an object
-   delete-obj       Delete an object from the chain blockstore
-   stat-obj         Collect size and ipld link counts for objs
-   getmessage       Get and print a message by its cid
-   sethead          manually set the local nodes head tipset (Caution: normally only used for recovery)
-   list, love       View a segment of the chain
-   get              Get chain DAG node by path
-   bisect           bisect chain for an event
-   export           export chain to a car file
-   slash-consensus  Report consensus fault
-   gas-price        Estimate gas prices
-   inspect-usage    Inspect block space usage of a given tipset
-   decode           decode various types
-   encode           encode various types
-   disputer         interact with the window post disputer
-   help, h          Shows a list of commands or help for one command
+   head                              Print chain head
+   get-block, getblock               Get a block and print its details
+   read-obj                          Read the raw bytes of an object
+   delete-obj                        Delete an object from the chain blockstore
+   stat-obj                          Collect size and ipld link counts for objs
+   getmessage, get-message, get-msg  Get and print a message by its cid
+   sethead, set-head                 manually set the local nodes head tipset (Caution: normally only used for recovery)
+   list, love                        View a segment of the chain
+   get                               Get chain DAG node by path
+   bisect                            bisect chain for an event
+   export                            export chain to a car file
+   slash-consensus                   Report consensus fault
+   gas-price                         Estimate gas prices
+   inspect-usage                     Inspect block space usage of a given tipset
+   decode                            decode various types
+   encode                            encode various types
+   disputer                          interact with the window post disputer
+   help, h                           Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)
@@ -2155,18 +2079,8 @@ OPTIONS:
    
 ```
 
-### lotus chain getblock
+#### lotus chain get-block, getblock
 ```
-NAME:
-   lotus chain getblock - Get a block and print its details
-
-USAGE:
-   lotus chain getblock [command options] [blockCid]
-
-OPTIONS:
-   --raw       print just the raw block header (default: false)
-   --help, -h  show help (default: false)
-   
 ```
 
 ### lotus chain read-obj
@@ -2195,7 +2109,6 @@ DESCRIPTION:
 
 OPTIONS:
    --really-do-it  (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -2215,36 +2128,15 @@ DESCRIPTION:
 
 OPTIONS:
    --base value  ignore links found in this obj
-   --help, -h    show help (default: false)
    
 ```
 
-### lotus chain getmessage
+##### lotus chain getmessage, get-message, get-msg
 ```
-NAME:
-   lotus chain getmessage - Get and print a message by its cid
-
-USAGE:
-   lotus chain getmessage [command options] [messageCid]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
 ```
 
-### lotus chain sethead
+#### lotus chain sethead, set-head
 ```
-NAME:
-   lotus chain sethead - manually set the local nodes head tipset (Caution: normally only used for recovery)
-
-USAGE:
-   lotus chain sethead [command options] [tipsetkey]
-
-OPTIONS:
-   --genesis      reset head to genesis (default: false)
-   --epoch value  reset head to given epoch (default: 0)
-   --help, -h     show help (default: false)
-   
 ```
 
 #### lotus chain list, love
@@ -2291,9 +2183,8 @@ DESCRIPTION:
 
 OPTIONS:
    --as-type value  specify type to interpret output as
-   --verbose        (default: false)
    --tipset value   specify tipset for /pstate (pass comma separated array of cids)
-   --help, -h       show help (default: false)
+   --verbose        (default: false)
    
 ```
 
@@ -2333,10 +2224,9 @@ USAGE:
    lotus chain export [command options] [outputPath]
 
 OPTIONS:
-   --tipset value             specify tipset to start the export from (default: "@head")
    --recent-stateroots value  specify the number of recent state roots to include in the export (default: 0)
    --skip-old-msgs            (default: false)
-   --help, -h                 show help (default: false)
+   --tipset value             specify tipset to start the export from (default: "@head")
    
 ```
 
@@ -2349,9 +2239,8 @@ USAGE:
    lotus chain slash-consensus [command options] [blockCid1 blockCid2]
 
 OPTIONS:
-   --from value   optionally specify the account to report consensus from
    --extra value  Extra block cid
-   --help, -h     show help (default: false)
+   --from value   optionally specify the account to report consensus from
    
 ```
 
@@ -2377,10 +2266,9 @@ USAGE:
    lotus chain inspect-usage [command options] [arguments...]
 
 OPTIONS:
-   --tipset value       specify tipset to view block space usage of (default: "@head")
    --length value       length of chain to inspect block space usage for (default: 1)
    --num-results value  number of results to print per category (default: 10)
-   --help, -h           show help (default: false)
+   --tipset value       specify tipset to view block space usage of (default: "@head")
    
 ```
 
@@ -2410,9 +2298,8 @@ USAGE:
    lotus chain decode params [command options] [toAddr method params]
 
 OPTIONS:
-   --tipset value    
    --encoding value  specify input encoding to parse (default: "base64")
-   --help, -h        show help (default: false)
+   --tipset value    
    
 ```
 
@@ -2442,10 +2329,9 @@ USAGE:
    lotus chain encode params [command options] [dest method params]
 
 OPTIONS:
-   --tipset value    
    --encoding value  specify input encoding to parse (default: "base64")
+   --tipset value    
    --to-code         interpret dest as code CID instead of as address (default: false)
-   --help, -h        show help (default: false)
    
 ```
 
@@ -2479,7 +2365,6 @@ USAGE:
 
 OPTIONS:
    --start-epoch value  only start disputing PoSts after this epoch  (default: 0)
-   --help, -h           show help (default: false)
    
 ```
 
@@ -2556,8 +2441,7 @@ DESCRIPTION:
       GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr
 
 OPTIONS:
-   --system value  limit to log system
-   --help, -h      show help (default: false)
+   --system value  limit to log system  (accepts multiple inputs)
    
 ```
 
@@ -2570,8 +2454,7 @@ USAGE:
    lotus log alerts [command options] [arguments...]
 
 OPTIONS:
-   --all       get all (active and inactive) alerts (default: false)
-   --help, -h  show help (default: false)
+   --all  get all (active and inactive) alerts (default: false)
    
 ```
 
@@ -2588,7 +2471,6 @@ CATEGORY:
 
 OPTIONS:
    --timeout value  duration to wait till fail (default: 30s)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -2617,21 +2499,23 @@ USAGE:
    lotus net command [command options] [arguments...]
 
 COMMANDS:
-   peers           Print peers
-   connect         Connect to a peer
-   listen          List listen addresses
-   id              Get node identity
-   findpeer        Find the addresses of a given peerID
-   scores          Print peers' pubsub scores
-   reachability    Print information about reachability from the internet
-   bandwidth       Print bandwidth usage information
-   block           Manage network connection gating rules
-   stat            Report resource usage for a scope
-   limit           Get or set resource limits for a scope
-   protect         Add one or more peer IDs to the list of protected peer connections
-   unprotect       Remove one or more peer IDs from the list of protected peer connections.
-   list-protected  List the peer IDs with protected connection.
-   help, h         Shows a list of commands or help for one command
+   peers                Print peers
+   ping                 Ping peers
+   connect              Connect to a peer
+   disconnect           Disconnect from a peer
+   listen               List listen addresses
+   id                   Get node identity
+   find-peer, findpeer  Find the addresses of a given peerID
+   scores               Print peers' pubsub scores
+   reachability         Print information about reachability from the internet
+   bandwidth            Print bandwidth usage information
+   block                Manage network connection gating rules
+   stat                 Report resource usage for a scope
+   limit                Get or set resource limits for a scope
+   protect              Add one or more peer IDs to the list of protected peer connections
+   unprotect            Remove one or more peer IDs from the list of protected peer connections.
+   list-protected       List the peer IDs with protected connection.
+   help, h              Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)
@@ -2649,7 +2533,20 @@ USAGE:
 OPTIONS:
    --agent, -a     Print agent name (default: false)
    --extended, -x  Print extended peer information in json (default: false)
-   --help, -h      show help (default: false)
+   
+```
+
+### lotus net ping
+```
+NAME:
+   lotus net ping - Ping peers
+
+USAGE:
+   lotus net ping [command options] [arguments...]
+
+OPTIONS:
+   --count value, -c value     specify the number of times it should ping (default: 10)
+   --interval value, -i value  minimum time between pings (default: 1s)
    
 ```
 
@@ -2660,6 +2557,19 @@ NAME:
 
 USAGE:
    lotus net connect [command options] [peerMultiaddr|minerActorAddress]
+
+OPTIONS:
+   --help, -h  show help (default: false)
+   
+```
+
+### lotus net disconnect
+```
+NAME:
+   lotus net disconnect - Disconnect from a peer
+
+USAGE:
+   lotus net disconnect [command options] [peerID]
 
 OPTIONS:
    --help, -h  show help (default: false)
@@ -2692,17 +2602,8 @@ OPTIONS:
    
 ```
 
-### lotus net findpeer
+#### lotus net find-peer, findpeer
 ```
-NAME:
-   lotus net findpeer - Find the addresses of a given peerID
-
-USAGE:
-   lotus net findpeer [command options] [peerId]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
 ```
 
 ### lotus net scores
@@ -2715,7 +2616,6 @@ USAGE:
 
 OPTIONS:
    --extended, -x  print extended peer scores in json (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -2743,7 +2643,6 @@ USAGE:
 OPTIONS:
    --by-peer      list bandwidth usage by peer (default: false)
    --by-protocol  list bandwidth usage by protocol (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -2915,7 +2814,7 @@ DESCRIPTION:
      - all           -- reports the resource usage for all currently active scopes.
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --json  (default: false)
    
 ```
 
@@ -2940,8 +2839,7 @@ DESCRIPTION:
     The limit is json-formatted, with the same structure as the limits file.
 
 OPTIONS:
-   --set       set the limit for a scope (default: false)
-   --help, -h  show help (default: false)
+   --set  set the limit for a scope (default: false)
    
 ```
 
@@ -3028,8 +2926,7 @@ USAGE:
    lotus sync wait [command options] [arguments...]
 
 OPTIONS:
-   --watch     don't exit after node is synced (default: false)
-   --help, -h  show help (default: false)
+   --watch  don't exit after node is synced (default: false)
    
 ```
 
@@ -3055,8 +2952,7 @@ USAGE:
    lotus sync unmark-bad [command options] [blockCid]
 
 OPTIONS:
-   --all       drop the entire bad block cache (default: false)
-   --help, -h  show help (default: false)
+   --all  drop the entire bad block cache (default: false)
    
 ```
 
@@ -3083,7 +2979,6 @@ USAGE:
 
 OPTIONS:
    --epoch value  checkpoint the tipset at the given epoch (default: 0)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -3099,7 +2994,6 @@ CATEGORY:
    STATUS
 
 OPTIONS:
-   --chain     include chain health status (default: false)
-   --help, -h  show help (default: false)
+   --chain  include chain health status (default: false)
    
 ```

--- a/content/en/storage-providers/operate/lotus-miner-cli.md
+++ b/content/en/storage-providers/operate/lotus-miner-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Lotus-miner CLI"
 description: "Reference documentation for the lotus-miner command-line interface."
-lead: "Reference documentation for the lotus-miner command-line interface. This documentation was automatically generated using Lotus v1.15.1"
+lead: "Reference documentation for the lotus-miner command-line interface. This documentation was automatically generated using Lotus v1.17.0"
 draft: false
 menu:
     storage-providers:
@@ -11,7 +11,7 @@ weight: 375
 toc: true
 ---
 
-<!-- This page was copied from https://raw.githubusercontent.com/filecoin-project/lotus/release/v1.15.1/documentation/en/cli-lotus-miner.md -->
+<!-- This page was copied from https://raw.githubusercontent.com/filecoin-project/lotus/release/v1.17.0/documentation/en/cli-lotus-miner.md -->
 
 # lotus-miner
 ```
@@ -22,7 +22,7 @@ USAGE:
    lotus-miner [global options] command [command options] [arguments...]
 
 VERSION:
-   1.15.1-rc3
+   1.17.0
 
 COMMANDS:
    init     Initialize a lotus miner repo
@@ -58,13 +58,14 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --actor value, -a value                  specify other actor to query / manipulate
-   --color                                  use color in display output (default: depends on output being a TTY)
-   --miner-repo value, --storagerepo value  Specify miner repo path. flag(storagerepo) and env(LOTUS_STORAGE_PATH) are DEPRECATION, will REMOVE SOON (default: "~/.lotusminer") [$LOTUS_MINER_PATH, $LOTUS_STORAGE_PATH]
-   --markets-repo value                     Markets repo path [$LOTUS_MARKETS_PATH]
    --call-on-markets                        (experimental; may be removed) call this command against a markets node; use only with common commands like net, auth, pprof, etc. whose target may be ambiguous (default: false)
-   --vv                                     enables very verbose mode, useful for debugging the CLI (default: false)
+   --color                                  use color in display output (default: depends on output being a TTY)
    --help, -h                               show help (default: false)
+   --markets-repo value                     Markets repo path [$LOTUS_MARKETS_PATH]
+   --miner-repo value, --storagerepo value  Specify miner repo path. flag(storagerepo) and env(LOTUS_STORAGE_PATH) are DEPRECATION, will REMOVE SOON (default: "~/.lotusminer") [$LOTUS_MINER_PATH, $LOTUS_STORAGE_PATH]
    --version, -v                            print the version (default: false)
+   --vv                                     enables very verbose mode, useful for debugging the CLI (default: false)
+   
 ```
 
 ## lotus-miner init
@@ -86,7 +87,7 @@ OPTIONS:
    --worker value, -w value     worker key to use (overrides --create-worker-key)
    --owner value, -o value      owner key to use
    --sector-size value          specify sector size to use (default: "32GiB")
-   --pre-sealed-sectors value   specify set of presealed sectors for starting as a genesis miner
+   --pre-sealed-sectors value   specify set of presealed sectors for starting as a genesis miner  (accepts multiple inputs)
    --pre-sealed-metadata value  specify the metadata file for the presealed sectors
    --nosync                     don't check full-node sync status (default: false)
    --symlink-imported-sectors   attempt to symlink to presealed sectors instead of copying them into place (default: false)
@@ -106,10 +107,9 @@ USAGE:
    lotus-miner init restore [command options] [backupFile]
 
 OPTIONS:
-   --nosync                don't check full-node sync status (default: false)
    --config value          config file (config.toml)
+   --nosync                don't check full-node sync status (default: false)
    --storage-config value  storage paths config (storage.json)
-   --help, -h              show help (default: false)
    
 ```
 
@@ -122,12 +122,11 @@ USAGE:
    lotus-miner init service [command options] [backupFile]
 
 OPTIONS:
-   --config value            config file (config.toml)
-   --nosync                  don't check full-node sync status (default: false)
-   --type value              type of service to be enabled
    --api-sealer value        sealer API info (lotus-miner auth api-info --perm=admin)
    --api-sector-index value  sector Index API info (lotus-miner auth api-info --perm=admin)
-   --help, -h                show help (default: false)
+   --config value            config file (config.toml)
+   --nosync                  don't check full-node sync status (default: false)
+   --type value              type of service to be enabled  (accepts multiple inputs)
    
 ```
 
@@ -140,11 +139,10 @@ USAGE:
    lotus-miner run [command options] [arguments...]
 
 OPTIONS:
-   --miner-api value     2345
    --enable-gpu-proving  enable use of GPU for mining operations (default: true)
-   --nosync              don't check full-node sync status (default: false)
    --manage-fdlimit      manage open file limit (default: true)
-   --help, -h            show help (default: false)
+   --miner-api value     2345
+   --nosync              don't check full-node sync status (default: false)
    
 ```
 
@@ -189,7 +187,6 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -203,7 +200,6 @@ USAGE:
 
 OPTIONS:
    --no-comment  don't comment default values (default: false)
-   --help, -h    show help (default: false)
    
 ```
 
@@ -224,8 +220,7 @@ DESCRIPTION:
    this command must be within this base path
 
 OPTIONS:
-   --offline   create backup without the node running (default: false)
-   --help, -h  show help (default: false)
+   --offline  create backup without the node running (default: false)
    
 ```
 
@@ -251,35 +246,24 @@ USAGE:
    lotus-miner actor command [command options] [arguments...]
 
 COMMANDS:
-   set-addrs              set addresses that your miner can be publicly dialed on
-   withdraw               withdraw available balance
-   repay-debt             pay down a miner's debt
-   set-peer-id            set the peer id of your miner
-   set-owner              Set owner address (this command should be invoked twice, first with the old owner as the senderAddress, and then with the new owner)
-   control                Manage control addresses
-   propose-change-worker  Propose a worker address change
-   confirm-change-worker  Confirm a worker address change
-   compact-allocated      compact allocated sectors bitfield
-   help, h                Shows a list of commands or help for one command
+   set-addresses, set-addrs  set addresses that your miner can be publicly dialed on
+   withdraw                  withdraw available balance
+   repay-debt                pay down a miner's debt
+   set-peer-id               set the peer id of your miner
+   set-owner                 Set owner address (this command should be invoked twice, first with the old owner as the senderAddress, and then with the new owner)
+   control                   Manage control addresses
+   propose-change-worker     Propose a worker address change
+   confirm-change-worker     Confirm a worker address change
+   compact-allocated         compact allocated sectors bitfield
+   help, h                   Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)
    
 ```
 
-### lotus-miner actor set-addrs
+#### lotus-miner actor set-addresses, set-addrs
 ```
-NAME:
-   lotus-miner actor set-addrs - set addresses that your miner can be publicly dialed on
-
-USAGE:
-   lotus-miner actor set-addrs [command options] [arguments...]
-
-OPTIONS:
-   --gas-limit value  set gas limit (default: 0)
-   --unset            unset address (default: false)
-   --help, -h         show help (default: false)
-   
 ```
 
 ### lotus-miner actor withdraw
@@ -292,7 +276,6 @@ USAGE:
 
 OPTIONS:
    --confidence value  number of block confirmations to wait for (default: 5)
-   --help, -h          show help (default: false)
    
 ```
 
@@ -306,7 +289,6 @@ USAGE:
 
 OPTIONS:
    --from value  optionally specify the account to send funds from
-   --help, -h    show help (default: false)
    
 ```
 
@@ -320,7 +302,6 @@ USAGE:
 
 OPTIONS:
    --gas-limit value  set gas limit (default: 0)
-   --help, -h         show help (default: false)
    
 ```
 
@@ -334,7 +315,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -365,9 +345,8 @@ USAGE:
    lotus-miner actor control list [command options] [arguments...]
 
 OPTIONS:
-   --verbose   (default: false)
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color    use color in display output (default: depends on output being a TTY)
+   --verbose  (default: false)
    
 ```
 
@@ -381,7 +360,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -395,7 +373,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -409,7 +386,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  Actually send transaction performing the action (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -425,7 +401,6 @@ OPTIONS:
    --mask-last-offset value  Mask sector IDs from 0 to 'higest_allocated - offset' (default: 0)
    --mask-upto-n value       Mask sector IDs from 0 to 'n' (default: 0)
    --really-do-it            Actually send transaction performing the action (default: false)
-   --help, -h                show help (default: false)
    
 ```
 
@@ -489,7 +464,6 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   --help, -h    show help (default: false)
    
 ```
 
@@ -503,7 +477,6 @@ USAGE:
 
 OPTIONS:
    --perm value  permission to assign to the token, one of: read, write, sign, admin
-   --help, -h    show help (default: false)
    
 ```
 
@@ -567,8 +540,7 @@ DESCRIPTION:
       GOLOG_OUTPUT    - Specify whether to output to file, stderr, stdout or a combination, i.e. file+stderr
 
 OPTIONS:
-   --system value  limit to log system
-   --help, -h      show help (default: false)
+   --system value  limit to log system  (accepts multiple inputs)
    
 ```
 
@@ -581,8 +553,7 @@ USAGE:
    lotus-miner log alerts [command options] [arguments...]
 
 OPTIONS:
-   --all       get all (active and inactive) alerts (default: false)
-   --help, -h  show help (default: false)
+   --all  get all (active and inactive) alerts (default: false)
    
 ```
 
@@ -599,7 +570,6 @@ CATEGORY:
 
 OPTIONS:
    --timeout value  duration to wait till fail (default: 30s)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -671,7 +641,6 @@ OPTIONS:
    --format value  output format of data, supported: table, json (default: "table")
    --verbose, -v   (default: false)
    --watch         watch deal updates in real-time, rather than a one time list (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -729,11 +698,10 @@ USAGE:
    lotus-miner storage-deals selection reject [command options] [arguments...]
 
 OPTIONS:
-   --online      (default: false)
    --offline     (default: false)
-   --verified    (default: false)
+   --online      (default: false)
    --unverified  (default: false)
-   --help, -h    show help (default: false)
+   --verified    (default: false)
    
 ```
 
@@ -746,11 +714,10 @@ USAGE:
    lotus-miner storage-deals set-ask [command options] [arguments...]
 
 OPTIONS:
+   --max-piece-size SIZE   Set maximum piece size (w/bit-padding, in bytes) in ask to SIZE (default: miner sector size)
+   --min-piece-size SIZE   Set minimum piece size (w/bit-padding, in bytes) in ask to SIZE (default: 256B)
    --price PRICE           Set the price of the ask for unverified deals (specified as FIL / GiB / Epoch) to PRICE.
    --verified-price PRICE  Set the price of the ask for verified deals (specified as FIL / GiB / Epoch) to PRICE
-   --min-piece-size SIZE   Set minimum piece size (w/bit-padding, in bytes) in ask to SIZE (default: 256B)
-   --max-piece-size SIZE   Set maximum piece size (w/bit-padding, in bytes) in ask to SIZE (default: miner sector size)
-   --help, -h              show help (default: false)
    
 ```
 
@@ -789,7 +756,6 @@ USAGE:
    lotus-miner storage-deals get-blocklist [command options] [arguments...]
 
 OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 
@@ -829,7 +795,6 @@ USAGE:
 
 OPTIONS:
    --publish-now  send a publish message now (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -920,9 +885,8 @@ USAGE:
    lotus-miner retrieval-deals selection reject [command options] [arguments...]
 
 OPTIONS:
-   --online    (default: false)
-   --offline   (default: false)
-   --help, -h  show help (default: false)
+   --offline  (default: false)
+   --online   (default: false)
    
 ```
 
@@ -948,11 +912,10 @@ USAGE:
    lotus-miner retrieval-deals set-ask [command options] [arguments...]
 
 OPTIONS:
-   --price value                      Set the price of the ask for retrievals (FIL/GiB)
-   --unseal-price value               Set the price to unseal
    --payment-interval value           Set the payment interval (in bytes) for retrieval (default: 1MiB)
    --payment-interval-increase value  Set the payment interval increase (in bytes) for retrieval (default: 1MiB)
-   --help, -h                         show help (default: false)
+   --price value                      Set the price of the ask for retrievals (FIL/GiB)
+   --unseal-price value               Set the price to unseal
    
 ```
 
@@ -998,12 +961,11 @@ USAGE:
    lotus-miner data-transfers list [command options] [arguments...]
 
 OPTIONS:
-   --verbose, -v  print verbose transfer details (default: false)
    --color        use color in display output (default: depends on output being a TTY)
    --completed    show completed data transfers (default: false)
-   --watch        watch deal updates in real-time, rather than a one time list (default: false)
    --show-failed  show failed/cancelled transfers (default: false)
-   --help, -h     show help (default: false)
+   --verbose, -v  print verbose transfer details (default: false)
+   --watch        watch deal updates in real-time, rather than a one time list (default: false)
    
 ```
 
@@ -1016,9 +978,8 @@ USAGE:
    lotus-miner data-transfers restart [command options] [arguments...]
 
 OPTIONS:
-   --peerid value  narrow to transfer with specific peer
    --initiator     specify only transfers where peer is/is not initiator (default: false)
-   --help, -h      show help (default: false)
+   --peerid value  narrow to transfer with specific peer
    
 ```
 
@@ -1031,10 +992,9 @@ USAGE:
    lotus-miner data-transfers cancel [command options] [arguments...]
 
 OPTIONS:
-   --peerid value          narrow to transfer with specific peer
-   --initiator             specify only transfers where peer is/is not initiator (default: false)
    --cancel-timeout value  time to wait for cancel to be sent to client (default: 5s)
-   --help, -h              show help (default: false)
+   --initiator             specify only transfers where peer is/is not initiator (default: false)
+   --peerid value          narrow to transfer with specific peer
    
 ```
 
@@ -1061,6 +1021,7 @@ USAGE:
 
 COMMANDS:
    list-shards       List all shards known to the dagstore, with their current status
+   register-shard    Register a shard
    initialize-shard  Initialize the specified shard
    recover-shard     Attempt to recover a shard in errored state
    initialize-all    Initialize all uninitialized shards, streaming results as they're produced; only shards for unsealed pieces are initialized by default
@@ -1082,8 +1043,20 @@ USAGE:
    lotus-miner dagstore list-shards [command options] [arguments...]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
+   
+```
+
+### lotus-miner dagstore register-shard
+```
+NAME:
+   lotus-miner dagstore register-shard - Register a shard
+
+USAGE:
+   lotus-miner dagstore register-shard [command options] [key]
+
+OPTIONS:
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1096,8 +1069,7 @@ USAGE:
    lotus-miner dagstore initialize-shard [command options] [key]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1110,8 +1082,7 @@ USAGE:
    lotus-miner dagstore recover-shard [command options] [key]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1124,10 +1095,9 @@ USAGE:
    lotus-miner dagstore initialize-all [command options] [arguments...]
 
 OPTIONS:
+   --color              use color in display output (default: depends on output being a TTY)
    --concurrency value  maximum shards to initialize concurrently at a time; use 0 for unlimited (default: 0)
    --include-sealed     initialize sealed pieces as well (default: false)
-   --color              use color in display output (default: depends on output being a TTY)
-   --help, -h           show help (default: false)
    
 ```
 
@@ -1140,8 +1110,7 @@ USAGE:
    lotus-miner dagstore gc [command options] [arguments...]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1154,8 +1123,7 @@ USAGE:
    lotus-miner dagstore lookup-pieces [command options] <cid>
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1186,8 +1154,7 @@ USAGE:
    lotus-miner index announce [command options] <deal proposal cid>
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1200,8 +1167,7 @@ USAGE:
    lotus-miner index announce-all [command options] [arguments...]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -1214,21 +1180,23 @@ USAGE:
    lotus-miner net command [command options] [arguments...]
 
 COMMANDS:
-   peers           Print peers
-   connect         Connect to a peer
-   listen          List listen addresses
-   id              Get node identity
-   findpeer        Find the addresses of a given peerID
-   scores          Print peers' pubsub scores
-   reachability    Print information about reachability from the internet
-   bandwidth       Print bandwidth usage information
-   block           Manage network connection gating rules
-   stat            Report resource usage for a scope
-   limit           Get or set resource limits for a scope
-   protect         Add one or more peer IDs to the list of protected peer connections
-   unprotect       Remove one or more peer IDs from the list of protected peer connections.
-   list-protected  List the peer IDs with protected connection.
-   help, h         Shows a list of commands or help for one command
+   peers                Print peers
+   ping                 Ping peers
+   connect              Connect to a peer
+   disconnect           Disconnect from a peer
+   listen               List listen addresses
+   id                   Get node identity
+   find-peer, findpeer  Find the addresses of a given peerID
+   scores               Print peers' pubsub scores
+   reachability         Print information about reachability from the internet
+   bandwidth            Print bandwidth usage information
+   block                Manage network connection gating rules
+   stat                 Report resource usage for a scope
+   limit                Get or set resource limits for a scope
+   protect              Add one or more peer IDs to the list of protected peer connections
+   unprotect            Remove one or more peer IDs from the list of protected peer connections.
+   list-protected       List the peer IDs with protected connection.
+   help, h              Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)
@@ -1246,7 +1214,20 @@ USAGE:
 OPTIONS:
    --agent, -a     Print agent name (default: false)
    --extended, -x  Print extended peer information in json (default: false)
-   --help, -h      show help (default: false)
+   
+```
+
+### lotus-miner net ping
+```
+NAME:
+   lotus-miner net ping - Ping peers
+
+USAGE:
+   lotus-miner net ping [command options] [arguments...]
+
+OPTIONS:
+   --count value, -c value     specify the number of times it should ping (default: 10)
+   --interval value, -i value  minimum time between pings (default: 1s)
    
 ```
 
@@ -1257,6 +1238,19 @@ NAME:
 
 USAGE:
    lotus-miner net connect [command options] [peerMultiaddr|minerActorAddress]
+
+OPTIONS:
+   --help, -h  show help (default: false)
+   
+```
+
+### lotus-miner net disconnect
+```
+NAME:
+   lotus-miner net disconnect - Disconnect from a peer
+
+USAGE:
+   lotus-miner net disconnect [command options] [peerID]
 
 OPTIONS:
    --help, -h  show help (default: false)
@@ -1289,17 +1283,8 @@ OPTIONS:
    
 ```
 
-### lotus-miner net findpeer
+#### lotus-miner net find-peer, findpeer
 ```
-NAME:
-   lotus-miner net findpeer - Find the addresses of a given peerID
-
-USAGE:
-   lotus-miner net findpeer [command options] [peerId]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
 ```
 
 ### lotus-miner net scores
@@ -1312,7 +1297,6 @@ USAGE:
 
 OPTIONS:
    --extended, -x  print extended peer scores in json (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -1340,7 +1324,6 @@ USAGE:
 OPTIONS:
    --by-peer      list bandwidth usage by peer (default: false)
    --by-protocol  list bandwidth usage by protocol (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -1512,7 +1495,7 @@ DESCRIPTION:
      - all           -- reports the resource usage for all currently active scopes.
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --json  (default: false)
    
 ```
 
@@ -1537,8 +1520,7 @@ DESCRIPTION:
     The limit is json-formatted, with the same structure as the limits file.
 
 OPTIONS:
-   --set       set the limit for a scope (default: false)
-   --help, -h  show help (default: false)
+   --set  set the limit for a scope (default: false)
    
 ```
 
@@ -1627,7 +1609,6 @@ USAGE:
 
 OPTIONS:
    --verbose, -v  (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -1671,6 +1652,7 @@ COMMANDS:
    refs                  List References to sectors
    update-state          ADVANCED: manually update the state of a sector, this may aid in error recovery
    pledge                store random data in a sector
+   precommits            Print on-chain precommit info
    check-expire          Inspect expiring sectors
    expired               Get or cleanup expired sectors
    renew                 Renew expiring sectors while not exceeding each sector's max life
@@ -1679,12 +1661,12 @@ COMMANDS:
    remove                Forcefully remove a sector (WARNING: This means losing power and collateral for the removed sector (use 'terminate' for lower penalty))
    snap-up               Mark a committed capacity sector to be filled with deals
    abort-upgrade         Abort the attempted (SnapDeals) upgrade of a CC sector, reverting it to as before
-   mark-for-upgrade      Mark a committed capacity sector for replacement by a sector with deals
    seal                  Manually start sealing a sector (filling any unused space with junk)
    set-seal-delay        Set the time, in minutes, that a new sector waits for deals before sealing starts
    get-cc-collateral     Get the collateral required to pledge a committed capacity sector
    batching              manage batch sector operations
    match-pending-pieces  force a refreshed match of pending pieces to open sectors without manually waiting for more deals
+   compact-partitions    removes dead sectors from partitions and reduces the number of partitions used if possible
    help, h               Shows a list of commands or help for one command
 
 OPTIONS:
@@ -1705,7 +1687,6 @@ OPTIONS:
    --on-chain-info, -c   show sector on chain info (default: false)
    --partition-info, -p  show partition related info (default: false)
    --proof               print snark proof bytes as hex (default: false)
-   --help, -h            show help (default: false)
    
 ```
 
@@ -1718,15 +1699,14 @@ USAGE:
    lotus-miner sectors list [command options] [arguments...]
 
 OPTIONS:
-   --show-removed, -r    show removed sectors (default: false)
    --color, -c           use color in display output (default: depends on output being a TTY)
-   --fast, -f            don't show on-chain info for better performance (default: false)
    --events, -e          display number of events the sector has received (default: false)
+   --fast, -f            don't show on-chain info for better performance (default: false)
    --initial-pledge, -p  display initial pledge (default: false)
    --seal-time, -t       display how long it took for the sector to be sealed (default: false)
+   --show-removed, -r    show removed sectors (default: false)
    --states value        filter sectors by a comma-separated list of states
    --unproven, -u        only show sectors which aren't in the 'Proving' state (default: false)
-   --help, -h            show help (default: false)
    
 ```
 
@@ -1753,7 +1733,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -1770,6 +1749,19 @@ OPTIONS:
    
 ```
 
+### lotus-miner sectors precommits
+```
+NAME:
+   lotus-miner sectors precommits - Print on-chain precommit info
+
+USAGE:
+   lotus-miner sectors precommits [command options] [arguments...]
+
+OPTIONS:
+   --help, -h  show help (default: false)
+   
+```
+
 ### lotus-miner sectors check-expire
 ```
 NAME:
@@ -1780,7 +1772,6 @@ USAGE:
 
 OPTIONS:
    --cutoff value  skip sectors whose current expiration is more than <cutoff> epochs from now, defaults to 60 days (default: 172800)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -1793,10 +1784,9 @@ USAGE:
    lotus-miner sectors expired [command options] [arguments...]
 
 OPTIONS:
-   --show-removed         show removed sectors (default: false)
-   --remove-expired       remove expired sectors (default: false)
    --expired-epoch value  epoch at which to check sector expirations (default: WinningPoSt lookback epoch)
-   --help, -h             show help (default: false)
+   --remove-expired       remove expired sectors (default: false)
+   --show-removed         show removed sectors (default: false)
    
 ```
 
@@ -1809,16 +1799,15 @@ USAGE:
    lotus-miner sectors renew [command options] [arguments...]
 
 OPTIONS:
-   --from value            only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120 (1 hour) (default: 0)
-   --to value              only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 92160 (32 days) (default: 0)
-   --sector-file value     provide a file containing one sector number in each line, ignoring above selecting criteria
    --exclude value         optionally provide a file containing excluding sectors
    --extension value       try to extend selected sectors by this number of epochs, defaults to 540 days (default: 1555200)
-   --new-expiration value  try to extend selected sectors to this epoch, ignoring extension (default: 0)
-   --tolerance value       don't try to extend sectors by fewer than this number of epochs, defaults to 7 days (default: 20160)
+   --from value            only consider sectors whose current expiration epoch is in the range of [from, to], <from> defaults to: now + 120 (1 hour) (default: 0)
    --max-fee value         use up to this amount of FIL for one message. pass this flag to avoid message congestion. (default: "0")
+   --new-expiration value  try to extend selected sectors to this epoch, ignoring extension (default: 0)
    --really-do-it          pass this flag to really renew sectors, otherwise will only print out json representation of parameters (default: false)
-   --help, -h              show help (default: false)
+   --sector-file value     provide a file containing one sector number in each line, ignoring above selecting criteria
+   --to value              only consider sectors whose current expiration epoch is in the range of [from, to], <to> defaults to: now + 92160 (32 days) (default: 0)
+   --tolerance value       don't try to extend sectors by fewer than this number of epochs, defaults to 7 days (default: 20160)
    
 ```
 
@@ -1831,13 +1820,12 @@ USAGE:
    lotus-miner sectors extend [command options] <sectorNumbers...>
 
 OPTIONS:
-   --new-expiration value     new expiration epoch (default: 0)
-   --v1-sectors               renews all v1 sectors up to the maximum possible lifetime (default: false)
-   --tolerance value          when extending v1 sectors, don't try to extend sectors by fewer than this number of epochs (default: 20160)
-   --expiration-ignore value  when extending v1 sectors, skip sectors whose current expiration is less than <ignore> epochs from now (default: 120)
-   --expiration-cutoff value  when extending v1 sectors, skip sectors whose current expiration is more than <cutoff> epochs from now (infinity if unspecified) (default: 0)
                               
-   --help, -h                 show help (default: false)
+   --expiration-cutoff value  when extending v1 sectors, skip sectors whose current expiration is more than <cutoff> epochs from now (infinity if unspecified) (default: 0)
+   --expiration-ignore value  when extending v1 sectors, skip sectors whose current expiration is less than <ignore> epochs from now (default: 120)
+   --new-expiration value     new expiration epoch (default: 0)
+   --tolerance value          when extending v1 sectors, don't try to extend sectors by fewer than this number of epochs (default: 20160)
+   --v1-sectors               renews all v1 sectors up to the maximum possible lifetime (default: false)
    
 ```
 
@@ -1896,7 +1884,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   --help, -h      show help (default: false)
    
 ```
 
@@ -1923,20 +1910,6 @@ USAGE:
 
 OPTIONS:
    --really-do-it  pass this flag if you know what you are doing (default: false)
-   --help, -h      show help (default: false)
-   
-```
-
-### lotus-miner sectors mark-for-upgrade
-```
-NAME:
-   lotus-miner sectors mark-for-upgrade - Mark a committed capacity sector for replacement by a sector with deals
-
-USAGE:
-   lotus-miner sectors mark-for-upgrade [command options] <sectorNum>
-
-OPTIONS:
-   --help, -h  show help (default: false)
    
 ```
 
@@ -1976,7 +1949,6 @@ USAGE:
 
 OPTIONS:
    --expiration value  the epoch when the sector will expire (default: 0)
-   --help, -h          show help (default: false)
    
 ```
 
@@ -2008,7 +1980,6 @@ USAGE:
 
 OPTIONS:
    --publish-now  send a batch now (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -2022,7 +1993,6 @@ USAGE:
 
 OPTIONS:
    --publish-now  send a batch now (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -2039,6 +2009,22 @@ OPTIONS:
    
 ```
 
+### lotus-miner sectors compact-partitions
+```
+NAME:
+   lotus-miner sectors compact-partitions - removes dead sectors from partitions and reduces the number of partitions used if possible
+
+USAGE:
+   lotus-miner sectors compact-partitions [command options] [arguments...]
+
+OPTIONS:
+   --actor value       Specify the address of the miner to run this command
+   --deadline value    the deadline to compact the partitions in (default: 0)
+   --partitions value  list of partitions to compact sectors in  (accepts multiple inputs)
+   --really-do-it      Actually send transaction performing the action (default: false)
+   
+```
+
 ## lotus-miner proving
 ```
 NAME:
@@ -2050,9 +2036,11 @@ USAGE:
 COMMANDS:
    info       View current state information
    deadlines  View the current proving period deadlines information
-   deadline   View the current proving period deadline information by its index 
+   deadline   View the current proving period deadline information by its index
    faults     View the currently known proving faulty sectors information
    check      Check sectors provable
+   workers    list workers
+   compute    Compute simulated proving tasks
    help, h    Shows a list of commands or help for one command
 
 OPTIONS:
@@ -2089,13 +2077,13 @@ OPTIONS:
 ### lotus-miner proving deadline
 ```
 NAME:
-   lotus-miner proving deadline - View the current proving period deadline information by its index 
+   lotus-miner proving deadline - View the current proving period deadline information by its index
 
 USAGE:
    lotus-miner proving deadline [command options] <deadlineIdx>
 
 OPTIONS:
-   --help, -h  show help (default: false)
+   --sector-nums, -n  Print sector/fault numbers belonging to this deadline (default: false)
    
 ```
 
@@ -2121,11 +2109,45 @@ USAGE:
    lotus-miner proving check [command options] <deadlineIdx>
 
 OPTIONS:
+   --faulty            only check faulty sectors (default: false)
    --only-bad          print only bad sectors (default: false)
    --slow              run slower checks (default: false)
    --storage-id value  filter sectors by storage path (path id)
-   --help, -h          show help (default: false)
    
+```
+
+### lotus-miner proving workers
+```
+NAME:
+   lotus-miner proving workers - list workers
+
+USAGE:
+   lotus-miner proving workers [command options] [arguments...]
+
+OPTIONS:
+   --color  use color in display output (default: depends on output being a TTY)
+   
+```
+
+### lotus-miner proving compute
+```
+NAME:
+   lotus-miner proving compute - Compute simulated proving tasks
+
+USAGE:
+   lotus-miner proving compute command [command options] [arguments...]
+
+COMMANDS:
+   windowed-post, window-post  Compute WindowPoSt for a specific deadline
+   help, h                     Shows a list of commands or help for one command
+
+OPTIONS:
+   --help, -h  show help (default: false)
+   
+```
+
+##### lotus-miner proving compute windowed-post, window-post
+```
 ```
 
 ## lotus-miner storage
@@ -2184,14 +2206,13 @@ DESCRIPTION:
    over time
 
 OPTIONS:
+   --allow-to value     path groups allowed to pull data from this path (allow all if not specified)  (accepts multiple inputs)
+   --groups value       path group names                                                              (accepts multiple inputs)
    --init               initialize the path first (default: false)
-   --weight value       (for init) path weight (default: 10)
+   --max-storage value  (for init) limit storage space for sectors (expensive for very large paths!)
    --seal               (for init) use path for sealing (default: false)
    --store              (for init) use path for long-term storage (default: false)
-   --max-storage value  (for init) limit storage space for sectors (expensive for very large paths!)
-   --groups value       path group names
-   --allow-to value     path groups allowed to pull data from this path (allow all if not specified)
-   --help, -h           show help (default: false)
+   --weight value       (for init) path weight (default: 10)
    
 ```
 
@@ -2222,8 +2243,7 @@ USAGE:
    lotus-miner storage list sectors [command options] [arguments...]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -2249,8 +2269,7 @@ USAGE:
    lotus-miner storage cleanup [command options] [arguments...]
 
 OPTIONS:
-   --removed   cleanup remaining files from removed sectors (default: true)
-   --help, -h  show help (default: false)
+   --removed  cleanup remaining files from removed sectors (default: true)
    
 ```
 
@@ -2280,6 +2299,7 @@ COMMANDS:
    workers     list workers
    sched-diag  Dump internal scheduler state
    abort       Abort a running job
+   data-cid    Compute data CID using workers
    help, h     Shows a list of commands or help for one command
 
 OPTIONS:
@@ -2298,7 +2318,6 @@ USAGE:
 OPTIONS:
    --color          use color in display output (default: depends on output being a TTY)
    --show-ret-done  show returned but not consumed calls (default: false)
-   --help, -h       show help (default: false)
    
 ```
 
@@ -2311,8 +2330,7 @@ USAGE:
    lotus-miner sealing workers [command options] [arguments...]
 
 OPTIONS:
-   --color     use color in display output (default: depends on output being a TTY)
-   --help, -h  show help (default: false)
+   --color  use color in display output (default: depends on output being a TTY)
    
 ```
 
@@ -2326,7 +2344,6 @@ USAGE:
 
 OPTIONS:
    --force-sched  (default: false)
-   --help, -h     show help (default: false)
    
 ```
 
@@ -2340,5 +2357,18 @@ USAGE:
 
 OPTIONS:
    --help, -h  show help (default: false)
+   
+```
+
+### lotus-miner sealing data-cid
+```
+NAME:
+   lotus-miner sealing data-cid - Compute data CID using workers
+
+USAGE:
+   lotus-miner sealing data-cid [command options] [file/url] <padded piece size>
+
+OPTIONS:
+   --file-size value  real file size (default: 0)
    
 ```

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -42,11 +42,11 @@ This section will cover the installation, configuration and running a Lotus seal
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.16.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout tags/v1.15.0
+    git checkout releases
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -52,11 +52,11 @@ This section will cover the installation, configuration and starting a lotus nod
     Follow the prompts to install Rust, and then run these commands:
      
     ```shell
-    wget -c https://golang.org/dl/go1.16.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout tags/v1.13.2
+    git checkout tags/v1.17.0
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1
@@ -150,11 +150,11 @@ This section will cover the installation, configuration, and how to start the lo
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.16.4.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout tags/v1.13.2
+    git checkout tags/v1.17.0
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -92,16 +92,11 @@ A lite-node lets your computer interact with the Filecoin network without having
 You can install Lotus on MacOS 10.11 El Capitan or higher. You must have [Homebrew](https://brew.sh/) installed.
 {{< /alert >}}
 
-1. Add the `filecoin-project/lotus` Homebrew tap:
+
+1. Install Lotus from the filecoin-project tap
 
     ```shell
-    brew tap filecoin-project/lotus
-    ```
-
-1. Install Lotus:
-
-    ```shell
-    brew install lotus
+    brew install filecoin-project/lotus/lotus 
     ```
 
 1. Lotus is now installed on your computer.
@@ -139,7 +134,7 @@ If Homebrew doesn't work for you, or if you prefer to build from source, try the
 1. Checkout the latest release
     
     ```shell
-    git checkout tags/v1.16.1
+    git checkout releases
     ```
 
 1. Setup some environment variables correctly
@@ -172,44 +167,38 @@ Now, you're ready to [run a Lotus lite node](/get-started/store-and-retrieve/set
 
 ### Linux
 
-<!-- There are two simple ways to install Lotus on Linux (this is tested on Ubuntu): -->
+There are two simple ways to install Lotus on Linux (this is tested on Ubuntu):
 
-The easiest way to install the lotus client is to use Snap.
-<!-- Commenting out AppImage until it builds again
-- [AppImage](#appimage) -->
+- [AppImage](#appimage)
 - [Snap](#snap)
 
 
-<!-- #### AppImage
-{{< alert icon="warning" >}}
-AppImage is not currently available, please use another option.
-{{< /alert >}}
 1. Update and upgrade your system:
 
     ```shell
     sudo apt update -y && sudo apt upgrade -y
     ```
 
-1. Download the latest `AppImage` file from the [Lotus GitHub releases page](https://github.com/filecoin-project/lotus/releases/):
+1. Download the latest `AppImage` file from the [Lotus GitHub releases page](https://github.com/filecoin-project/lotus/releases/latest):
 
     ```shell
-    wget https://github.com/filecoin-project/lotus/releases/download/v1.16.1/Lotus-v1.16.1-x86_64.AppImage
+    wget https://github.com/filecoin-project/lotus/releases/download/v1.17.0/Lotus-v1.17.0-x86_64.AppImage
     ```
 
 1. Make the `AppImage` executable:
 
     ```shell
-    chmod +x Lotus-v1.16.1-x86_64.AppImage
+    chmod +x Lotus-v1.17.0-x86_64.AppImage
     ```
 
 1. Move the `AppImage` to `/usr/local/bin` and rename it `lotus`:
 
     ```shell
-    sudo mv Lotus-v1.16.1-x86_64.AppImage /usr/local/bin/lotus
+    sudo mv Lotus-v1.17.0-x86_64.AppImage /usr/local/bin/lotus
     ```
 
 [Head onto the next section to run your Lotus lite-node ↓](#run-a-lotus-lite-node)
--->
+
 #### Snap
 
 {{< alert icon="warning" >}}**Requirements**
@@ -219,13 +208,13 @@ You must have [Snapd](https://snapcraft.io/docs/installing-snapd) installed.
 1. To install Lotus using Snap, run:
 
     ```shell
-    sudo snap install lotus-filecoin
+    sudo snap install lotus
     ```
 
-2. The snap installer automatically starts a full lotus node in the background. For the purposes of this tutorial, we don't want that, so stop it, and then we can run a lotus lite node instead.
+2. The snap installer automatically starts a full lotus node as a daemon. For the purposes of this tutorial, which uses a lite-node, we don't want that, so disable it, and then we can run a lotus lite-node instead.
 
     ```shell
-    sudo snap stop lotus-filecoin
+    sudo snap disable lotus
     ```
 
 [Head onto the next section to run your Lotus lite-node ↓](#run-a-lotus-lite-node)
@@ -238,10 +227,6 @@ Now that you have Lotus ready to run, you can start a Lotus lite-node on your co
 Just as a reminder, `api.chain.love` is a Lotus full-node managed by Protocol Labs. It's ideal for use in this tutorial, but should not be used in a development or in a production environment.
 {{< /alert >}}
 
-
-{{< alert icon="tip" >}}
-if you installed via Snap, the binary name is 'lotus-filecoin.lotus' instead of just 'lotus'
-{{< /alert >}}
 
 1. Open a terminal windows and run the `lotus daemon --lite` command, using `api.chain.love` as the full-node address:
 
@@ -258,6 +243,7 @@ if you installed via Snap, the binary name is 'lotus-filecoin.lotus' instead of 
     ```
 
 1. MacOS users may see a warning regarding Lotus. Select **Accept incoming connections** if you see a warning.
+
 1. The Lotus daemon will continue to run. You must run further commands from a separate terminal window.
 
 Next up is [getting a FIL address ↓](#get-a-fil-address)


### PR DESCRIPTION
- re-instated Snap and appImage in the tutorial and install flows
- updated to use new, cleaner, snap.
- changed the lite-node snap to disable, not just stop the daemon so it doesn't revive after reboot and eat your whole drive.
- updated various links to the github 'releases' page to be 'releases/latest' so they always point at the latest, where the target is meant to be the latest, and not the index of all releases.
- updated various 'git checkout x.x.x' to be 'git checkout releases' so it always pulls the latest stable.
- updated lotus and lotus-miner CLI docs from 1.15.1 to 1.17.0
- updated mimimum Go version to 1.17.9 
- a few typoes fixed 
