### PR TITLE
Lotus-wallet install instructions

### DIFF
--- a/content/en/kb/install-lotus-wallet/index.md
+++ b/content/en/kb/install-lotus-wallet/index.md
@@ -15,7 +15,7 @@ areas: ["lotus-wallet"]
 
 ## Problem:
 
-When installing Lotus for mainnet, lotus-shed is not installed by default. 
+When installing Lotus for mainnet, lotus-wallet is not installed by default. 
 
 ## Environment:
 

--- a/content/en/kb/install-lotus-wallet/index.md
+++ b/content/en/kb/install-lotus-wallet/index.md
@@ -1,0 +1,30 @@
+---
+title: "How to install lotus-wallet"
+description: "This is a guide for installing lotus-wallet."
+date: 2022-08-15T12:00:35+01:00
+lastmod: 2022-08-15T12:00:35+01:00
+draft: false
+menu:
+  kb:
+    parent: "browse"
+toc: false
+pinned: false
+types: ["article"]
+areas: ["lotus-wallet"]
+---
+
+## Problem:
+
+When installing Lotus for mainnet, lotus-shed is not installed by default. 
+
+## Environment:
+
+- Mainnet
+
+## Resolution:
+
+After lotus installs (completely) run `make install lotus-wallet`
+
+## Extras:
+
+Note that lotus-wallet is not required for lotus to run on the network. It only contains a tool for running a remote lotus wallet application.


### PR DESCRIPTION
Adds lotus-wallet install instructions, which is going to be linked to as a prerequisite in the `lotus-wallet` tutorial: https://github.com/filecoin-project/lotus-docs/pull/327