### PR TITLE
Update BELLMAN envvar to Rust

### DIFF
--- a/content/en/storage-providers/seal-workers/post-workers.md
+++ b/content/en/storage-providers/seal-workers/post-workers.md
@@ -57,7 +57,7 @@ The following environment variables are required to be set before starting the w
 
 ```shell
 export MINER_API_INFO:<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http
-export BELLMAN_CUSTOM_GPU="MODEL-NAME:CORES" # If you´re using a custom GPU
+export RUST_GPU_TOOLS_CUSTOM_GPU="MODEL-NAME:CORES" # If you´re using a custom GPU
 export FIL_PROOFS_PARAMETER_CACHE=/fast/disk/folder # > 100GiB!
 ```
 

--- a/content/en/storage-providers/setup/prerequisites.md
+++ b/content/en/storage-providers/setup/prerequisites.md
@@ -102,13 +102,13 @@ There are some changes in the latest Nvidia driver, so if you upgrade your drive
 If you are using an nvidia driver below `460.91.03`
 
 ```shell
-export BELLMAN_CUSTOM_GPU="GeForce RTX 3090:10496"
+export RUST_GPU_TOOLS_CUSTOM_GPU="GeForce RTX 3090:10496"
 ```
 
 If you are using an Nvidia driver above `510.47.03`
 
 ```shell
-export BELLMAN_CUSTOM_GPU="NVIDIA GeForce RTX 3090:10496"
+export RUST_GPU_TOOLS_CUSTOM_GPU="NVIDIA GeForce RTX 3090:10496"
 ```
 
 Nvidia RTX 3090 was used in this example. Remember to edit it with your GPU and amount of Cuda cores.

--- a/content/en/tutorials/lotus-miner/cuda.md
+++ b/content/en/tutorials/lotus-miner/cuda.md
@@ -29,13 +29,13 @@ Many Linux distributions provide their packages of the NVIDIA Linux Graphics Dri
     If you are using an nvidia driver below < `460.91.03`
     
     ```shell
-    export BELLMAN_CUSTOM_GPU="GeForce RTX 3090:10496"
+    export RUST_GPU_TOOLS_CUSTOM_GPU="GeForce RTX 3090:10496"
     ```
     
     If you are using an Nvidia driver above > `510.47.03`
     
     ```shell
-    export BELLMAN_CUSTOM_GPU="NVIDIA GeForce RTX 3090:10496"
+    export RUST_GPU_TOOLS_CUSTOM_GPU="NVIDIA GeForce RTX 3090:10496"
     ```
     
 Nvidia RTX 3090 was used in this example. Remember to edit it with your GPU and amount of Cuda cores.

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -42,7 +42,7 @@ This section will cover the installation, configuration and starting a lotus nod
 
 ### Installation
 
-1. We have bundled all the install steps into the below code snippets so you can just copy and paste them into your terminal. If you would prefer to run each command step by step, take a look at the [Installation guide]({{<relref "/lotus/install/linux#building-from-source" >}}). `FFI_USE_CUDA=1` variable forces the use of CUDA architecture instead of OpenCL for Nvidia cards. `BELLMAN_CUSTOM_GPU` variable need to be set after driver 475+ due to a change in naming convention.
+1. We have bundled all the install steps into the below code snippets so you can just copy and paste them into your terminal. If you would prefer to run each command step by step, take a look at the [Installation guide]({{<relref "/lotus/install/linux#building-from-source" >}}). `FFI_USE_CUDA=1` variable forces the use of CUDA architecture instead of OpenCL for Nvidia cards. `RUST_GPU_TOOLS_CUSTOM_GPU` variable need to be set after driver 475+ due to a change in naming convention.
     
     ```shell
     sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y && sudo apt upgrade -y
@@ -62,7 +62,7 @@ This section will cover the installation, configuration and starting a lotus nod
     export FFI_BUILD_FROM_SOURCE=1
     export RUSTFLAGS="-C target-cpu=native -g"
     export FFI_USE_CUDA=1
-    export BELLMAN_CUSTOM_GPU="Quadro RTX 6000:4608"
+    export RUST_GPU_TOOLS_CUSTOM_GPU="Quadro RTX 6000:4608"
     make clean calibnet
     ./lotus --version
     ```
@@ -140,7 +140,7 @@ This section will cover the installation, configuration, and how to start the lo
 
 ### Installation
 
-1. We have bundled all the install steps into the below code snippets so you can just copy and paste them into your terminal. If you would prefer to run each command step by step, take a look at the [Installation guide]({{<relref "/lotus/install/linux#building-from-source" >}}). `FFI_USE_CUDA=1` variable forces the use of CUDA architecture instead of OpenCL for Nvidia cards. `BELLMAN_CUSTOM_GPU` variable need to be set after driver 475+ due to a change in naming convention:
+1. We have bundled all the install steps into the below code snippets so you can just copy and paste them into your terminal. If you would prefer to run each command step by step, take a look at the [Installation guide]({{<relref "/lotus/install/linux#building-from-source" >}}). `FFI_USE_CUDA=1` variable forces the use of CUDA architecture instead of OpenCL for Nvidia cards. `RUST_GPU_TOOLS_CUSTOM_GPU` variable need to be set after driver 475+ due to a change in naming convention:
 
     ```shell
     sudo apt install mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y && sudo apt upgrade -y
@@ -160,7 +160,7 @@ This section will cover the installation, configuration, and how to start the lo
     export FFI_BUILD_FROM_SOURCE=1
     export RUSTFLAGS="-C target-cpu=native -g"
     export FFI_USE_CUDA=1
-    export BELLMAN_CUSTOM_GPU="Quadro RTX 6000:4608"
+    export RUST_GPU_TOOLS_CUSTOM_GPU="Quadro RTX 6000:4608"
     make clean calibnet
     ./lotus --version
     ```
@@ -193,7 +193,7 @@ This section will cover the installation, configuration, and how to start the lo
     export FIL_PROOFS_PARENT_CACHE=/home/miner/parent_cache   # > 50GiB!
 
     export FFI_USE_CUDA=1
-    export BELLMAN_CUSTOM_GPU="Quadro RTX 6000:4608"
+    export RUST_GPU_TOOLS_CUSTOM_GPU="Quadro RTX 6000:4608"
     
     export LOTUS_MINER_PATH=~/.lotusminer
     export GOLOG_OUTPUT=file


### PR DESCRIPTION
The BELLMAN_CUSTOM_GPU should now be defined as RUST_GPU_TOOLS_CUSTOM_GPU. Users already using BELLMAN_CUSTOM_GPU will not experience any immediate issues as it is backwards compatible.