### PR TITLE
Update Groups and AllowtTo

### DIFF
--- a/content/en/storage-providers/operate/custom-storage-layout.md
+++ b/content/en/storage-providers/operate/custom-storage-layout.md
@@ -38,8 +38,8 @@ You can filter for what sectors types are allowed in each sealing path by adjust
   "CanSeal": false,
   "CanStore": true,
   "MaxStorage": 0,
-  "Groups": [],
-  "AllowTo": [],
+  "Groups": null,
+  "AllowTo": null,
   "AllowTypes": null,
   "DenyTypes": null
 }
@@ -66,8 +66,8 @@ You can filter for what sector types that are allowed in each storage path by ad
   "CanSeal": false,
   "CanStore": true,
   "MaxStorage": 0,
-  "Groups": [],
-  "AllowTo": [],
+  "Groups": null,
+  "AllowTo": null,
   "AllowTypes": null,
   "DenyTypes": null
 }


### PR DESCRIPTION
I'm pretty sure it's still the case that specifying this as empty square brackets will cause storage/sealing path errors. Needs to be null or have a value.