### PR TITLE
Restructure the developer section

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -4,31 +4,26 @@
   weight = 10
 
 [[main]]
-  name = "Developers"
-  url = "/developers/glif-nodes"
-  weight = 20
-
-[[main]]
   name = "Storage Providers"
   url = "/storage-providers/get-started/overview"
-  weight = 30
+  weight = 20
 
 [[main]]
   name = "Tutorials"
   url = "/tutorials/lotus/store-and-retrieve/set-up/"
-  weight = 40
+  weight = 30
 
 [[main]]
   name = "Reference"
   url = "/reference/basics/overview/"
   identifier = "reference"
-  weight = 50
+  weight = 40
 
 [[main]]
   name = "Knowledge Base"
   url = "/kb"
   identifier = "kb"
-  weight = 60
+  weight = 50
 
 
 
@@ -57,8 +52,14 @@
   url = "/lotus/manage"
 
 [[lotus]]
-  name = "Project"
+  name = "Developers"
   weight = 50
+  identifier = "lotus-developers"
+  url = "/lotus/manage"
+
+[[lotus]]
+  name = "Project"
+  weight = 60
   identifier = "project"
   url = "/lotus/project"
 

--- a/config/_default/menus/menus.zh.toml
+++ b/config/_default/menus/menus.zh.toml
@@ -4,11 +4,6 @@
 #   weight = 10
 # 
 # [[main]]
-#   name = "Developers"
-#   url = "/developers/apis/json-rpc/"
-#   weight = 20
-# 
-# [[main]]
 #   name = "Storage Providers"
 #   url = "/storage-providers/get-started/overview"
 #   weight = 30
@@ -48,6 +43,12 @@
 #   identifier = "lotus-management"
 #   url = "/lotus/manage"
 # 
+#[[lotus]]
+# name = "Developers"
+# weight = 50
+# identifier = "lotus-developers"
+# url = "/lotus/developers"
+#
 # [[lotus]]
 #   name = "Project"
 #   weight = 50

--- a/content/en/lotus/developers/glif-nodes.md
+++ b/content/en/lotus/developers/glif-nodes.md
@@ -3,10 +3,11 @@ title: "Glif nodes"
 description: "Glif provides a number of synced Lotus node endpoints on the Filecoin testnets and mainnet."
 draft: false
 menu:
-    developers:
-             parent: "developers-nodes"
+    lotus:
+             parent: "lotus-developers"
 aliases:
     - /docs/developers/hosted-lotus/
+    - /developers/glif-nodes/
 weight: 105
 toc: true
 ---

--- a/content/en/lotus/developers/local-network.md
+++ b/content/en/lotus/developers/local-network.md
@@ -4,14 +4,15 @@ description: "Running a Filecoin network locally can be extremely useful for dev
 lead: "Running a Filecoin network locally can be extremely useful for developers wanting to build and test their applications. This page provides guidance on different methods to run a Filecoin network locally."
 draft: false
 menu:
-    developers:
-        parent: "developers-networks"
+    lotus:
+        parent: "lotus-developers"
         identifier: "developers-networks-local-network"
 weight: 305
 toc: true
 aliases:
     - /docs/developers/developer-network
     - /docs/developers/local-network/
+    - /developers/local-network/
 ---
 
 You can spin up a local network (local-net) using the regular Lotus binaries. This method will launch Lotus using 2 KiB sectors, allowing systems with fewer resources to run a local-net. This solution runs comfortably on a computer with 2 CPU cores and 4 GB RAM.

--- a/content/en/lotus/manage/switch-networks.md
+++ b/content/en/lotus/manage/switch-networks.md
@@ -14,7 +14,7 @@ toc: true
 
 As we mentioned in the installation guide, Lotus is compiled to operate on a single network, and the information in the configuration folder corresponds to that network.
 
-- Local devnet - [You can run a local devnet]({{< relref "../../developers/local-network/">}})
+- Local devnet - [You can run a local devnet]({{< relref "../developers/local-network/">}})
 - Testnets
     - [Calibnet](https://network.filecoin.io/#calibration)
     - [NerpaNet](https://github.com/filecoin-project/community/discussions/74#discussioncomment-1348469) was deprecated on 2021-08-16 and is no longer available.


### PR DESCRIPTION
Moving the developer-section from the top navigation-bar, and into the Lotus-section of the documentaion.