### PR TITLE
Section out output of commands

### DIFF
--- a/content/en/storage-providers/operate/backup-and-restore.md
+++ b/content/en/storage-providers/operate/backup-and-restore.md
@@ -28,10 +28,7 @@ This process backs-up metadata of the Lotus miner, which is needed to restore th
    ```shell with-output
    lotus-miner backup /root/lotus-backups/2020-11-15/backup.cbor
    ```
-
-   This will output something like:
-
-   ```
+   ```output
    Success
    ```
 
@@ -40,10 +37,7 @@ This process backs-up metadata of the Lotus miner, which is needed to restore th
    ```shell with-output
    lotus-miner backup --offline /root/lotus-backups/2020-11-15/backup.cbor
    ```
-
-   This will output something like:
-
-   ```
+   ```output
    Success
    ```
 
@@ -65,10 +59,7 @@ The backup is now complete. Always follow the 3-2-1 rule when storing backups:
    ```shell with-output
    lotus-miner init restore /root/lotus-backups/2020-11-15/backup.cbor
    ```
-
-   This will output something like:
-
-   ```
+   ```output
    ...
    2020-11-15T17:53:41.630Z        INFO    main    lotus-storage-miner/init_restore.go:254 Initializing libp2p identity
    2020-11-15T17:53:41.631Z        INFO    main    lotus-storage-miner/init_restore.go:266 Configuring miner actor

--- a/content/en/storage-providers/operate/connectivity.md
+++ b/content/en/storage-providers/operate/connectivity.md
@@ -40,8 +40,10 @@ There are different methods to test this:
 
 When the lotus miner is running and reachable, it should report it with:
 
-```sh
+```shell
 $ lotus-miner net reachability
+```
+```output
 AutoNAT status:  Public
 Public address:  /ip4/<IP>/tcp/<port>
 ```
@@ -52,8 +54,12 @@ Verify that the Public address corresponds to what you expect. `AutoNAT status: 
 
 To ensure storage and retrieval deals operate smoothly, it is recommended to check how many peers a miner is connected to after each start-up:
 
-```sh
+```shell
 lotus-miner net peers
+```
+```output
+QmUhB2wFQb4qsLZyoqVczMs6CgxSzQqij6gzmJ33Qeq8yn, [/ip4/<IP>/tcp/<port>]
+12D3KooWSVkZMoALKwWQpnkZoAHyPV1jYpciJ5ngwFSRv5LgWkwU, [/ip4/<IP>/tcp/<port>]
 ```
 
 The peer count should increase soon after starting the miner. You can also manually connect to peers with:

--- a/content/en/storage-providers/operate/custom-storage-layout.md
+++ b/content/en/storage-providers/operate/custom-storage-layout.md
@@ -116,7 +116,8 @@ You can see all your storage locations with the `lotus-miner storage list` comma
 
 ```shell
 lotus-miner storage list
-
+```
+```output
 Sealing:
 [##########                             ] 1.521 TiB/6.93 TiB 21%
   Unsealed: 1; Sealed: 2; Caches: 2; Reserved: 0 B
@@ -153,12 +154,15 @@ You can update sector locations with the `lotus-miner storage redeclare` command
 
 ```shell
 rsync -avP <source> <destination>
+```
+```output
 sending incremental file list
 s-t01024-1
 [......]
 sent 537,002,093 bytes  received 35 bytes  358,001,418.67 bytes/sec
 total size is 536,870,912  speedup is 1.00
 ```
+
 2. Redeclare the sector(s) in the new storage path.
 
 ```shell
@@ -171,6 +175,8 @@ You should now be able to see that the sectors has been redeclared in the new pa
 
 ```shell
 rsync -avP --remove-source-files <old-path> <backup-destination>
+```
+```output
 sending incremental file list
 sealed/
 sealed/s-t01024-1

--- a/content/en/storage-providers/operate/upgrades.md
+++ b/content/en/storage-providers/operate/upgrades.md
@@ -27,10 +27,7 @@ To export the default configuration files from Lotus, run:
 ```shell
 lotus-miner config default
 ```
-
-This will output something like:
-
-```toml
+```output
 [API]
   # Binding address for the Lotus API
   #
@@ -97,15 +94,19 @@ lotus daemon
 systemctl start lotus-daemon
 ```
 
+Wait for it to finish syncing
+
 ```shell
 lotus sync wait
 ```
 
-2. Start your `lotus-miner` and your `lotus-workers`
+2. Start your `lotus-miner`.
 
 ```shell
 lotus-miner run
 ```
+
+And your `lotus-workers`
 
 ```shell
 lotus-worker run


### PR DESCRIPTION
Separates between the command and output, to make things more clear and nicer in the docs.