### PR TITLE
Use `git checkout releases`

### DIFF
--- a/content/en/lotus/developers/local-network.md
+++ b/content/en/lotus/developers/local-network.md
@@ -179,7 +179,7 @@ Local-nets use slightly different binaries to those used in the Filecoin mainnet
    # if you need a specific release use 
    git checkout <tag_or_release>
    # For example:
-   git checkout v1.17.0 # tag for a release
+   # git checkout v1.17.0 # tag for a release
    ```
 
 4. Remove any existing repositories.

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -118,7 +118,7 @@ Because of the novel architecture of the M1-based Mac computers, some specific e
     ```shell
     cd extern/filecoin-ffi
     git fetch -a
-    git checkout master
+    git checkout releases
     ```
 
 1. Create the `filecoin-ffi` executables:

--- a/content/en/lotus/manage/troubleshooting.md
+++ b/content/en/lotus/manage/troubleshooting.md
@@ -21,7 +21,10 @@ toc: true
 Please check the build logs closely. If you have a dirty state in your git branch make sure to do something like:
 
 ```sh
-git checkout <desired_branch>
+git checkout releases
+# 'releases' always checks out the latest stable release
+# if you need a specific release use 
+# git checkout <tag_or_release>
 git reset origin/<desired_branch> --hard
 make clean
 ```

--- a/content/en/lotus/manage/upgrade.md
+++ b/content/en/lotus/manage/upgrade.md
@@ -18,7 +18,10 @@ Usually, if you are updating Lotus, it as simple as rebuilding and re-installing
 
 ```shell
 git pull
-git checkout <branch or tag>
+git checkout releases
+# 'releases' always checks out the latest stable release
+# if you need a specific release use 
+# git checkout <tag_or_release>
 ```
 
 Once the new version is checked-out, rebuild and re-install as explained in the installation guide.

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -56,7 +56,7 @@ This section will cover the installation, configuration and starting a lotus nod
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout tags/v1.17.0
+    git checkout releases
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1
@@ -154,7 +154,7 @@ This section will cover the installation, configuration, and how to start the lo
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout tags/v1.17.0
+    git checkout releases
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -46,7 +46,10 @@ The following the steps walk through how to install a Lotus node. Further, more 
     ```shell
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus
-    git checkout vX.X.X # tag for the latest release
+    git checkout releases
+    # 'releases' always checks out the latest stable release
+    # if you need a specific release use 
+    git checkout <tag_or_release>
     ```
 
 1. Build and install Lotus for the Calibration network:


### PR DESCRIPTION
Changes all the `git checkout <tag_or_release>` to `git checkout releases` throughout the documentation.

Also specifies in the comments that `releases` always checks out the latest stable release, and that if one needs a specific release, you should use `git checkout <tag_or_release>`.