### PR TITLE
Audit: Rename menu and change weight

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -44,17 +44,17 @@
   identifier = "lotus-install"
   url = "/lotus/install"
 
-[[lotus]]
-  name = "Configure"
-  weight = 30
-  identifier = "lotus-configure"
-  url = "/lotus/lotus-configure"
-
-[[lotus]]
+  [[lotus]]
   name = "Manage"
-  weight = 40
+  weight = 30
   identifier = "lotus-management"
   url = "/lotus/manage"
+
+[[lotus]]
+  name = "Advanced Configurations"
+  weight = 40
+  identifier = "lotus-configure"
+  url = "/lotus/lotus-configure"
 
 [[lotus]]
   name = "Developers"

--- a/config/_default/menus/menus.zh.toml
+++ b/config/_default/menus/menus.zh.toml
@@ -36,18 +36,18 @@
 #   weight = 20
 #   identifier = "lotus-install"
 #   url = "/lotus/install"
+#
+# [[lotus]]
+#   name = "Manage"
+#   weight = 30
+#   identifier = "lotus-management"
+#   url = "/lotus/manage"
 # 
 # [[lotus]]
 #   name = "Configure"
-#   weight = 30
+#   weight = 40
 #   identifier = "lotus-configure"
 #   url = "/lotus/lotus-configure"
-# 
-# [[lotus]]
-#   name = "Manage"
-#   weight = 40
-#   identifier = "lotus-management"
-#   url = "/lotus/manage"
 # 
 #[[lotus]]
 # name = "Developers"


### PR DESCRIPTION
As outlined in #360 moving the "Manage" section higher in the sub menu, and renaming configure to Advanced Configurations