### PR TITLE
Audit: Move "Nodes in China" page

### DIFF
--- a/content/en/kb/nodes-in-china/index.md
+++ b/content/en/kb/nodes-in-china/index.md
@@ -1,16 +1,24 @@
 ---
 title: "Nodes in China"
-description: "This guide provides a few tips for users in China to get around some of the bandwidth issues or slowness they can suffer when building and running Lotus."
-lead: "This guide provides a few tips for users in China to get around some of the bandwidth issues or slowness they can suffer when building and running Lotus."
+description: "This article provides a few tips for users in China to get around some of the bandwidth issues or slowness they can suffer when building and running Lotus."
+date: 2022-09-19T00:00:35+01:00
+lastmod: 2022-09-19T00:00:35+01:00
 draft: false
 menu:
-    lotus:
-        parent: "lotus-configure"
+  kb:
+    parent: "browse"
 aliases:
     - /docs/set-up/nodes-in-china/
-weight: 320
-toc: true
+    - /lotus/configure/nodes-in-china/
+toc: false
+pinned: false
+types: ["article"]
+areas: ["Lotus Node", "Lotus Miner"]
 ---
+
+## Problem
+
+Users in China might experience bandwidth issues or slowness when building and downloading proof paramaters needed to run Lotus. This article provides a few tips to get around the bandwidth issues.
 
 ## Speed up proof parameter download for first boot
 

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -162,7 +162,7 @@ These instructions are for installing Lotus on an Intel or AMD-based Mac. If you
 
     The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
 
-1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "nodes-in-china" >}})".
+1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "../../kb/nodes-in-china/" >}})".
 1. Some older Intel and AMD processors without the ADX instruction support may panic with illegal instruction errors. To fix this, add the `CGO_CFLAGS` environment variable:
 
     ```shell

--- a/content/en/lotus/manage/troubleshooting.md
+++ b/content/en/lotus/manage/troubleshooting.md
@@ -33,7 +33,7 @@ make clean
 
 ## Slow builds/start from China
 
-See the [tips when running in China]({{< relref "nodes-in-china" >}}) guide.
+See the [tips when running in China]({{< relref "../../kb/nodes-in-china/" >}}) guide.
 
 ## Error: initializing node error: cbor input had wrong number of fields
 

--- a/content/en/storage-providers/seal-workers/post-workers.md
+++ b/content/en/storage-providers/seal-workers/post-workers.md
@@ -66,7 +66,7 @@ When the PoSt worker starts, it needs to read and verify the Filecoin proof para
 The PoSt workers will fail to start if the file descriptor limit is not set high enough. You can raise this limit temporarily before starting the worker by running the command `ulimit -n 1048576`. Although, we recommend setting it permanently by following the [Permanently Setting Your ULIMIT System Value]({{< relref "kb#soft-fd-limit" >}}) guide.
 
 {{< alert icon="tip" >}}
-When fetching parameter files, remember to set the [`IPFS_GATEWAY` variable when running from China]({{< relref "nodes-in-china" >}})
+When fetching parameter files, remember to set the [`IPFS_GATEWAY` variable when running from China]({{< relref "../../kb/nodes-in-china/" >}})
 {{< /alert >}}
 
 ### Run the PoSt worker

--- a/content/en/storage-providers/seal-workers/seal-workers.md
+++ b/content/en/storage-providers/seal-workers/seal-workers.md
@@ -84,7 +84,7 @@ export FIL_PROOFS_USE_MULTICORE_SDR=1
 ```
 
 {{< alert icon="tip" >}}
-When initially fetching parameter files, remember to set the [`IPFS_GATEWAY` variable when running from China]({{< relref "../../lotus/configure/nodes-in-china/" >}})
+When initially fetching parameter files, remember to set the [`IPFS_GATEWAY` variable when running from China]({{< relref "../../kb/nodes-in-china/" >}})
 {{< /alert >}}
 
 ### Run the worker


### PR DESCRIPTION
Moving the "Nodes in China" page to the knowledge base section of the Lotus Documentation. Also depreciates the page the was previously under /configure/nodes-in-china.

- Updates all the relrefs to use the knowledge base link