### PR TITLE
Update go-version

### DIFF
--- a/content/en/lotus/developers/local-network.md
+++ b/content/en/lotus/developers/local-network.md
@@ -69,10 +69,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 #### Go
 
-To build Lotus, you need a working installation of [Go 1.17.9 or higher](https://golang.org/dl/):
+To build Lotus, you need a working installation of [Go 1.18.1 or higher](https://golang.org/dl/):
 
 ```shell
-wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 
 {{< alert icon="tip">}}

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -114,10 +114,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Go
 
-To build Lotus, you need a working installation of [Go 1.17.9 or higher](https://golang.org/dl/):
+To build Lotus, you need a working installation of [Go 1.18.1 or higher](https://golang.org/dl/):
 
 ```shell
-wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 
 {{< alert icon="tip">}}

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -42,7 +42,7 @@ This section will cover the installation, configuration and running a Lotus seal
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -52,7 +52,7 @@ This section will cover the installation, configuration and starting a lotus nod
     Follow the prompts to install Rust, and then run these commands:
      
     ```shell
-    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
@@ -150,7 +150,7 @@ This section will cover the installation, configuration, and how to start the lo
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.17.9.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/


### PR DESCRIPTION
Updates the minimum required go-version, as Lotus v1.17.2 now needs go version 1.18.1 or higher

Fixes #382 