### PR TITLE
removed references to AMD as there are no AMD macs. fixed a typo.

### DIFF
--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -159,15 +159,6 @@ These instructions are for installing Lotus on an Intel Mac. If you have an M1-b
     The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
 
 1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "../../kb/nodes-in-china/" >}})".
-1. Some older Intel and AMD processors without the ADX instruction support may panic with illegal instruction errors. To fix this, add the `CGO_CFLAGS` environment variables:
-
-    ```shell
-    export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
-    export CGO_CFLAGS="-D__BLST_PORTABLE__"
-    export PATH="$(brew --prefix coreutils)/libexec/gnubin:/usr/local/bin:$PATH"
-    ```
-
-    This is due to a Lotus bug that prevents Lotus from running on a processor without `adx` instruction support, and should be fixed soon.
 
 1. Build and install Lotus:
 

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -96,13 +96,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 The installation instructions are different depending on which CPU is in your Mac:
 
 - [M1-based CPUs](#m1-based-cpus)
-- [Intel and AMD-based CPUs](#intel-and-amd-based-cpus)
+- [Intel CPUs](#intel-cpus)
 
 #### M1-based CPUs
-
-{{< alert icon="warning">}}
-These instructions are for installing Lotus on an M1-based Mac. If you have an Intel or AMD-based CPU, use the [Intel and AMD-based CPU instructions ↓](#intel-and-amd-based-cpus)
-{{< /alert >}}
 
 1. Clone the repository:
 
@@ -119,7 +115,7 @@ These instructions are for installing Lotus on an M1-based Mac. If you have an I
 
     The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
 
-1. Create necessary environment variable to allow Lotus to run on ARM architecture:
+1. Create the necessary environment variables to allow Lotus to run on M1 architecture:
 
     ```shell
     export LIBRARY_PATH=/opt/homebrew/lib
@@ -141,10 +137,10 @@ These instructions are for installing Lotus on an M1-based Mac. If you have an I
 
 1. You should now have Lotus installed. You can now [start the Lotus daemon](#start-the-lotus-daemon-and-sync-the-chain).
 
-#### Intel and AMD-based CPUs
+#### Intel CPUs
 
 {{< alert icon="warning">}}
-These instructions are for installing Lotus on an Intel or AMD-based Mac. If you have an M1-based CPU, use the [M1-based CPU instructions ↑](#m1-based-cpus)
+These instructions are for installing Lotus on an Intel Mac. If you have an M1-based CPU, use the [M1-based CPU instructions ↑](#m1-based-cpus)
 {{< /alert >}}
 
 1. Clone the repository:
@@ -163,7 +159,7 @@ These instructions are for installing Lotus on an Intel or AMD-based Mac. If you
     The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
 
 1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "../../kb/nodes-in-china/" >}})".
-1. Some older Intel and AMD processors without the ADX instruction support may panic with illegal instruction errors. To fix this, add the `CGO_CFLAGS` environment variable:
+1. Some older Intel and AMD processors without the ADX instruction support may panic with illegal instruction errors. To fix this, add the `CGO_CFLAGS` environment variables:
 
     ```shell
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6327,9 +6327,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -13616,9 +13616,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
-      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dev": true,
       "requires": {
         "data-uri-to-buffer": "^4.0.0",


### PR DESCRIPTION
subject says all. I think we can probably tidy this up further and eliminate separate instructions for the two architectures but I'll do that in a follow up PR.