### PR TITLE
Remove mentions of misnamed "full chain" snapshots

### DIFF
--- a/content/en/lotus/manage/chain-management.md
+++ b/content/en/lotus/manage/chain-management.md
@@ -16,12 +16,11 @@ toc: true
 
 Lotus will automatically sync to the latest _chain head_ by fetching the block headers from the current _head_ down to the last synced epoch. The node then retrieves and verifies all the blocks from the last synced epoch to the current head. Once Lotus is synced, it will learn about new blocks as they are mined for every epoch and verify them accordingly. Every epoch might see a variable number of mined blocks.
 
-Filecoin's blockchain grows relatively fast and a full sync will take a long time. Lotus offers a faster way to sync by using trusted state snapshots. There are two types of snapshot available:
+Filecoin's blockchain is complex and grows relatively fast. It takes about 4 seconds to verify a tipset, which in turn means it takes about 1 month to validate 700,000 tipsets. As syncing the chain from genesis is no longer practical, an alternative is to obtain a collection of all IPLD blocks one needs to continue validating the chain state going forward. Such a collection is called a snapshot. Current;y one such snapshot is available
 
-| Name                                 | End height    | Message start height        | State start height          |
-| ------------------------------------ | ------------- | --------------------------- | --------------------------- |
-| [Lightweight](#lightweight-snapshot) | Current block | Current block - 2000 blocks | Current block - 2000 blocks |
-| [Full chain](#full-chain-snapshot)   | Current block | Genesis block               | Current block - 2000 blocks |
+| Name                                 | End height   | Message start height       | State start height          |
+| ------------------------------------ | ------------ | -------------------------- | --------------------------- |
+| [Lightweight](#lightweight-snapshot) | Recent block | Recent block - 1802 blocks | Current block - 1802 blocks |
 
 ### Lightweight snapshot
 
@@ -88,41 +87,6 @@ lotus daemon --import-snapshot https://snapshots.mainnet.filops.net/minimal/late
 lotus daemon --import-snapshot https://snapshots.calibrationnet.filops.net/minimal/latest
 ```
 
-### Full chain snapshot
-
-Full chain snapshots contain every block from genesis until the current tipset. You can trustlessly import these complete snapshots by supplying the `--import-chain` option to recalculate the entire state during import:
-
-```shell
-lotus daemon --import-chain https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/complete_chain_with_finality_stateroots_latest.car
-```
-
-This operation will take multiple days due to the size and complexity of the Filecoin blockchain.
-
-### Checking sync status
-
-There are two ways to check your Lotus daemon's chain synching progress.
-
-#### Sync status
-
-Use `sync status` to output the current state of your local chain:
-
-```shell
-lotus sync status
-```
-
-This will output something like:
-
-```shell
-sync status:
-worker 0:
-        Base:   [bafy2bzacecnamqgqmifpluoeldx7zzglxcljo6oja4vrmtj7432rphldpdmm2]
-        Target: [bafy2bzaceb4b3ionbbxz4uqoehzkjlt4ayta7bneh2bh5xatnwypeuqypebmw bafy2bzaceb2uct4pawanule5bt2ivepcgqls6e6f52lccofvdyfynyfnsa3aa bafy2bzacealylayv2mpgx7wkf54diu6vqmw5yubdgkauii7q2fb7hvwk4343i] (414300)
-        Height diff:    414300
-        Stage: header sync
-        Height: 414300
-        Elapsed: 765.267091ms
-```
-
 #### Sync wait
 
 Use `sync wait` to output the state of your current chain as an ongoing process:
@@ -154,36 +118,20 @@ Mon 24 Aug 2020 06:00:00 PM EDT
 
 ## Creating a snapshot
 
-A full chain CAR-snapshot can be created with `chain export`:
-
-```shell
-lotus chain export <filename>
-```
-
-To back up a certain number of the most recent state roots, use the `--recent-stateroots` option, along with how many state roots you would like to backup:
-
-```shell
-lotus chain export --recent-stateroots=2000 <filename>
-```
-
-To create a _pruned_ snapshot and only include blocks directly referenced by the exported state roots, add the `skip-old-msgs` option:
+A lightweight chain CAR-snapshot can be created with `chain export`:
 
 ```shell
 lotus chain export --recent-stateroots=2000 --skip-old-msgs <filename>
 ```
 
-{{< alert icon="warning" >}} This is a resource demanding task for the node. It may take up to 8 hours to create the CAR-snapshot, and the process will use around 70GB of RAM. {{< /alert >}}
+{{< alert icon="warning" >}} This is a resource demanding task for the node. It will take over an hour to create the CAR-snapshot, and the process will use around 100GB of RAM. {{< /alert >}}
 
 ## Restoring a custom snapshot
 
 You can restore snapshots by starting the daemon with the `--import-snapshot` option:
 
 ```shell
-# Without verification
 lotus daemon --import-snapshot <filename>
-
-# With verification
-lotus daemon --import-chain <filename>
 ```
 
 If you do not want the daemon to start once the snapshot has finished, add the `--halt-after-import` flag:


### PR DESCRIPTION
These snaps take an extreme amount of time to produce, and are not useful for a casual user anyway ( parsing them does not tell one about the fate of a message )

Additionally the sha256 suggestion is bogus: nobody ever recommended doing this, but leaving cleaning this up to another PR.
