### PR TITLE
Tutorial: Specify that restart is needed

### DIFF
--- a/content/en/tutorials/lotus/import-data-from-ipfs.md
+++ b/content/en/tutorials/lotus/import-data-from-ipfs.md
@@ -28,7 +28,7 @@ Lotus supports making deals with data stored in [IPFS](https://ipfs.io), without
     UseIpfs = true
     ```
 
-1. Restart your IPFS daemon.
+1. Restart your IPFS and Lotus daemon.
 1. You should now be able to make deals with the data associated with your IPFS node:
 
     ```shell

--- a/content/en/tutorials/lotus/import-data-from-ipfs.md
+++ b/content/en/tutorials/lotus/import-data-from-ipfs.md
@@ -45,6 +45,6 @@ Lotus supports making deals with data stored in [IPFS](https://ipfs.io), without
 1. You can now use that IPFS hash with `lotus` to create a storage deal.
 
     ```shell
-    lotus client deal QmV8FbWfaHeEVPMAzWM5paifwf94VFrpvehQqFZez5T6RW t01000 
+    lotus client deal QmV8FbWfaHeEVPMAzWM5paifwf94VFrpvehQqFZez5T6RW t01000 <price> <duration>
 ```
 


### PR DESCRIPTION
Specify that you need to restart the Lotus daemon after changing the config to be able to import data from IPFS.

Closes #399 