### PR TITLE
Move Dagstore page to kb

### DIFF
--- a/content/en/kb/dagstore/index.md
+++ b/content/en/kb/dagstore/index.md
@@ -1,18 +1,25 @@
 ---
 title: "Dagstore"
 description: "The dagstore is a sharded store to hold large IPLD graphs efficiently, packaged as location-transparent attachable CAR files, with mechanical sympathy resulting in zero-copy access in ideal situations."
-lead: "The dagstore is a sharded store to hold large IPLD graphs efficiently, packaged as location-transparent attachable CAR files, with mechanical sympathy resulting in zero-copy access in ideal situations."
+date: 2023-02-14T12:00:35+01:00
+lastmod: 2023-02-14T12:00:35+01:00
 draft: false
 menu:
-    storage-providers:
-        parent: "storage-providers-operate"
-        identifier: "storage-providers-configure-dagstore"
+  kb:
+    parent: "browse"
 aliases:
     - /docs/storage-providers/dagstore/
     - /storage-providers/configure/dagstore/
-weight: 335
-toc: true
+    - /storage-providers/operate/dagstore/
+toc: false
+pinned: false
+types: ["article"]
+areas: ["deprecated"]
 ---
+
+{{< alert icon="warning" >}}
+The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users to use the [Boost markets sub-system](https://github.com/filecoin-project/boost)
+{{< /alert >}}
 
 ## Conceptual overview
 

--- a/content/en/kb/dynamic-retrieval-pricing/index.md
+++ b/content/en/kb/dynamic-retrieval-pricing/index.md
@@ -13,7 +13,7 @@ aliases:
 toc: false
 pinned: false
 types: ["article"]
-areas: ["depricated"]
+areas: ["deprecated"]
 ---
 
 {{< alert icon="warning" >}}

--- a/content/en/kb/index-provider/index.md
+++ b/content/en/kb/index-provider/index.md
@@ -20,7 +20,7 @@ areas: ["Deprecated"]
  The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users to use the [Boost markets sub-system](https://github.com/filecoin-project/boost)
  {{< /alert >}}
 
-The index provider is a component of the _markets_ subsystem that enables content routing backed by the Filecoin network: it announces what content is stored by a storage provider by advertising the list of multihashes extracted from CARv2 indices stored by [DagStore]({{< relref "../../storage-providers/operate/dagstore/" >}}) along with metadata on how to retrieve the content. The indexing announcements are then published onto a gossipsub topic, which is listened to by a set of indexer nodes.
+The index provider is a component of the _markets_ subsystem that enables content routing backed by the Filecoin network: it announces what content is stored by a storage provider by advertising the list of multihashes extracted from CARv2 indices stored by [DagStore]({{< relref "../../kb/dagstore/" >}}) along with metadata on how to retrieve the content. The indexing announcements are then published onto a gossipsub topic, which is listened to by a set of indexer nodes.
 
 The indexer nodes then process the advertisements to facilitate a service where a client can look up the storage provider that stores a given CID or multihash.
 


### PR DESCRIPTION
Part of #492

Move Dagstore to kb:
- Move the Dagstore page to kb - and add areas: Deprecated
- Add aliases
- Update relref path for Dagstore
- Update area-keyword for index-provider. Had a typo in it
- Remove dagstore-page from /storage-providers/operate/dagstore