### PR TITLE
Add Lassie retrieve tutorial

### DIFF
--- a/content/en/kb/legacy-retrieve-data/index.md
+++ b/content/en/kb/legacy-retrieve-data/index.md
@@ -7,9 +7,6 @@ draft: false
 menu:
   kb:
     parent: "browse"
-aliases:
-    - /tutorials/store-and-retrieve/retrieve-data/
-    - /tutorials/lotus/store-and-retrieve/retrieve-data/
 toc: false
 pinned: false
 types: ["article"]


### PR DESCRIPTION
Adds Lassie retrieve tutorial, replacing the legacy markets way of retrieving the data.

- Removes the aliases in the legacy markets way, and redirects users to the Lassie tutorial