### PR TITLE
Update Go-version

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -126,10 +126,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Go
 
-To build Lotus, you need a working installation of [Go 1.18.8 or higher](https://golang.org/dl/):
+To build Lotus, you need a working installation of [Go 1.19.7 or higher](https://golang.org/dl/):
 
 ```shell
-wget -c https://golang.org/dl/go1.18.8.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+wget -c https://golang.org/dl/go1.19.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 
 {{< alert icon="tip">}}


### PR DESCRIPTION
Go-version needs to be on 1.19.7 or higher with the Lotus v1.21.0 release.

Setting the Go version in the docs to v1.19.7 seems like the best approach, since that version is also supported on the Lotus v1.20.x releases