### PR TITLE
Change to CUDA by default in the docs

### DIFF
--- a/content/en/kb/Using-OpenCL/index.md
+++ b/content/en/kb/Using-OpenCL/index.md
@@ -1,0 +1,35 @@
+---
+title: "Using OpenCL or disabling GPU"
+description: "This article explains how to use OpenCL instead of CUDA, or disabling the GPU on the Lotus-Miner process"
+date: 2022-03-18T12:00:35+01:00
+lastmod: 2022-03-18T12:00:35+01:00
+draft: false
+menu:
+  kb:
+    parent: "browse"
+toc: false
+pinned: false
+areas: ["Lotus Miner"]
+types: ["article"]
+---
+
+This article explains how to use OpenCL instead of CUDA, or disabling the GPU entirely.
+
+### Using OpenCL instead of CUDA
+
+This step is only necessary if you are running an Nvidia GPU and would prefer to use OpenCL instead of CUDA. Please note that Cuda is recommended over OpenCL for sealing and proving workloads.
+
+
+First you need to install OpenCL through a package manager:
+
+```shell
+sudo apt update -y && sudo apt install -y nvidia-opencl-icd -y
+```
+
+Before building the Lotus-Miner binary you will need to export the `FFI_USE_OPENCL=1` enviroment variable, and then [building from source process]({{< relref "../../storage-providers/operate/upgrades/#upgrade-in-place" >}}).
+
+### Disable GPU
+
+You can also choose to disable the GPU entirely and instead make proving and sealing workloads be run on the CPU. Please note that this is not recommended.
+
+Before building the Lotus-Miner binary you will need to export the `FFI_NO_GPU=1` enviroment variable, and then [building from source process]({{< relref "../../storage-providers/operate/upgrades/#upgrade-in-place" >}}).

--- a/content/en/storage-providers/seal-workers/post-workers.md
+++ b/content/en/storage-providers/seal-workers/post-workers.md
@@ -51,7 +51,7 @@ Storage providers should design their worker sectors' access according to their 
 
 ### Environment variables
 
-Remember to have the appropriate `nvidia-drivers` and `nvidia-opencl-icd` installed if running OpenCL on your worker. If using CUDA, install the `CUDA-toolkit` and build lotus binaries with `FFI_USE_CUDA=1`
+Remember to install [CUDA]({{< relref "../../tutorials/lotus-miner/cuda" >}}) on your PoSt-worker. If you want to use OpenCL instead, [check out this article]({{< relref "../../kb/using-opencl/" >}}). 
 
 The following environment variables are required to be set before starting the worker:
 

--- a/content/en/storage-providers/seal-workers/seal-workers.md
+++ b/content/en/storage-providers/seal-workers/seal-workers.md
@@ -68,7 +68,6 @@ The seal workers will fail to start if the file descriptor limit is not set high
 # MINER_API_INFO as obtained before
 export MINER_API_INFO=<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
 export MARKETS_API_INFO=<TOKEN>:/ip4/<miner_api_address>/tcp/<port>/http`
-export FFI_USE_CUDA=1 # if using CUDA
 export FIL_PROOFS_USE_GPU_COLUMN_BUILDER=1 # when GPU is available
 export FIL_PROOFS_USE_GPU_TREE_BUILDER=1   # when GPU is available
 export FIL_PROOFS_PARAMETER_CACHE=/fast/disk/folder # > 100GiB!

--- a/content/en/storage-providers/setup/configuration.md
+++ b/content/en/storage-providers/setup/configuration.md
@@ -67,16 +67,6 @@ This location can be made of large capacity, albeit slower, spinning-disks.
 
 These prerequisites are optional and can be used on a case by case basis. Please make sure to understand the use case before performing these steps.
 
-### Using OpenCL instead of CUDA
-
-This step is only necessary if you are running an Nvidia GPU and would prefer to use OpenCL instead of CUDA. Please note that Cuda is recommended over OpenCL for sealing and proving workload. Most Linux distributions contain this package in their package manager:
-
-```shell
-sudo apt update -y && sudo apt install -y nvidia-opencl-icd -y
-```
-
-If you want to use OpenCL you do not need to compile FFI to use CUDA, so you can discard the `FFI_USE_CUDA` environment variable.
-
 ### Sealing performance
 
 It is recommended to set the following environment variables in the environment so that they are defined every time any of the lotus daemons are launched:

--- a/content/en/storage-providers/setup/prerequisites.md
+++ b/content/en/storage-providers/setup/prerequisites.md
@@ -27,13 +27,9 @@ Please make sure that the following prerequites are met whether you are planning
 ### Install CUDA
 
 1. Install the latest stable [Nvidia drivers and Cuda]({{< relref "../../tutorials/lotus-miner/cuda" >}}) if you have an Nvidia card on your machine. Nvidia cards have a better performance with Cuda when compared to OpenCL.
-2. Make sure you have followed the instructions to [install the Lotus suite]({{< relref "../../lotus/install/prerequisites" >}}) to build the `lotus-miner` binary. Make sure that you have built Lotus with "Native Filecoin FFI" and exported the following variable to compile FFI to use Cuda if using Nvidia cards.
+2. Make sure you have followed the instructions to [install the Lotus suite]({{< relref "../../lotus/install/linux/#building-from-source" >}}) to build the `lotus-miner` binary. Make sure that you have built Lotus with "Native Filecoin FFI".
 
-    ```shell
-    export FFI_USE_CUDA=1
-    ```
-
- Please do not use the `lotus-miner` binary created during Lotus node installation process as it does not include the above options.
+If you want to use OpenCL, or disable the GPU when building Lotus, [check out this article]({{< relref "../../kb/using-opencl/" >}}).
 
 ### Configure parameters location
 

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -42,7 +42,7 @@ This section will cover the installation, configuration and running a Lotus seal
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.19.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -52,7 +52,7 @@ This section will cover the installation, configuration and starting a lotus nod
     Follow the prompts to install Rust, and then run these commands:
      
     ```shell
-    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.19.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
@@ -150,7 +150,7 @@ This section will cover the installation, configuration, and how to start the lo
     Follow the prompts to install Rust, and then run these commands:
     
     ```shell
-    wget -c https://golang.org/dl/go1.18.1.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+    wget -c https://golang.org/dl/go1.19.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/


### PR DESCRIPTION
Closes #519 

Removing the FFI_USE_CUDA enviroment variable from multiple pages since CUDA is enabled by default through the FFI now.

Created a KB-article about using OpenCL and building without GPU.