### PR TITLE
Update cmd to get latest ParentBaseFee

### DIFF
--- a/content/en/kb/update-msg-gas-fee/index.md
+++ b/content/en/kb/update-msg-gas-fee/index.md
@@ -33,7 +33,7 @@ The messages stuck in `mpool` due to low gas fee can be updated with a higher ga
 1. Check the current base fee prices.
 
     ```shell
-    lotus chain head | xargs lotus chain getblock | jq -r .ParentBaseFee
+    lotus chain head | awk 'NR==1{print; exit}' | xargs lotus chain getblock | jq -r .ParentBaseFee
     ```
   
 2.  Replace the message with updated gas fee in the `mpool` using the below command


### PR DESCRIPTION
The previous cmd `lotus chain head | xargs lotus chain getblock | jq -r .ParentBaseFee` stopped working for me (lotus v1.21.0), so updating the cmd to get latest ParentBaseFee.