### PR TITLE
kb: `Lotus-Miner Sectors renew` cmd is removed

### DIFF
--- a/content/en/kb/sectors-renew-cmd/index.md
+++ b/content/en/kb/sectors-renew-cmd/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Lotus-Miner Sectors renew command"
+title: "Lotus-Miner Sectors renew command is removed"
 description: "The lotus-miner sectors renew command has been replaced by lotus-miner sectors extend"
 date: 2022-04-04T12:00:35+01:00
 lastmod: 2022-04-04T12:00:35+01:00
@@ -13,7 +13,7 @@ types: ["article"]
 areas: ["Deprecated"]
 ---
 
-The `lotus-miner sectors renew` command has been deprecated. It has been replaced by the `lotus-miner sectors extend` command.
+The `lotus-miner sectors renew` command has been deprecated and removed from the CLI. It has been replaced by the `lotus-miner sectors extend` command.
 
 The features and functionality from `lotus-miner sectors renew` has been ported over to the `lotus-miner sectors extend` command.
 

--- a/content/en/kb/sectors-renew-cmd/index.md
+++ b/content/en/kb/sectors-renew-cmd/index.md
@@ -1,0 +1,20 @@
+---
+title: "Lotus-Miner Sectors renew command"
+description: "The lotus-miner sectors renew command has been replaced by lotus-miner sectors extend"
+date: 2022-04-04T12:00:35+01:00
+lastmod: 2022-04-04T12:00:35+01:00
+draft: false
+menu:
+  kb:
+    parent: "browse"
+toc: false
+pinned: false
+types: ["article"]
+areas: ["Deprecated"]
+---
+
+The `lotus-miner sectors renew` command has been deprecated. It has been replaced by the `lotus-miner sectors extend` command.
+
+The features and functionality from `lotus-miner sectors renew` has been ported over to the `lotus-miner sectors extend` command.
+
+You can read more about sector extension in the [chores section of the docs]({{< relref "../../storage-providers/operate/daily-chores/#extend-sectors" >}})

--- a/content/en/kb/sectors-renew-cmd/index.md
+++ b/content/en/kb/sectors-renew-cmd/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Lotus-Miner Sectors renew command is removed"
+title: "Lotus-Miner Sectors renew command is removed from CLI"
 description: "The lotus-miner sectors renew command has been replaced by lotus-miner sectors extend"
 date: 2022-04-04T12:00:35+01:00
 lastmod: 2022-04-04T12:00:35+01:00


### PR DESCRIPTION
Part of: #526

kb article about `Lotus-Miner Sectors renew` cmd being replaced by `lotus-miner sectors extend`.