### PR TITLE
chore: simplify: starting lotus daemon

### DIFF
--- a/content/en/kb/Chain-Snapshots/index.md
+++ b/content/en/kb/Chain-Snapshots/index.md
@@ -21,7 +21,7 @@ These lightweight snapshots do not contain any message receipts.
 
 ## Snapshot Links
 
-The snapshot links issue a `302 Found` redirecting to the latest snapshot file. Snapshots files are named in the format of `<height>_YYYY_MM_DDTHH_MM_SSZ.car` where the date & time is the chain timestamp for the given height. The height is the highest TipSet height in the chain.
+The snapshot links issue a `302 Found` redirecting to the latest snapshot file. Snapshots files are named in the format of `<height>_YYYY_MM_DDTHH_MM_SSZ.car.zst` where the date & time is the chain timestamp for the given height. The height is the highest TipSet height in the chain.
 
 These links can be used directly with Lotus `--chain-import` flag, the redirect will be followed.
 

--- a/content/en/lotus/install/start-lotus.md
+++ b/content/en/lotus/install/start-lotus.md
@@ -18,12 +18,6 @@ Now that we have installed Lotus we can download a lightweight chain snapshot an
     aria2c -x5 https://snapshots.mainnet.filops.net/minimal/latest.zst
     ```
 
-1. Uncompress the downloaded snapshot:
-
-    ```shell
-    zstd -d 1419120_2022_10_24T18_00_00Z.car.zst
-    ```
-
 Now that we have downloaded a recent snapshot we can import the snapshot to Lotus and start the daemon process.
 
 ## Import snapshot and start the Lotus daemon
@@ -41,7 +35,7 @@ If you do not want the chain data folder at the default `~/.lotus` location, you
 
 ```shell
 # Replace the filename for the `.car` file based on the snapshot you downloaded.
-lotus daemon --import-snapshot path/to/1419120_2022_10_24T18_00_00Z.car --halt-after-import
+lotus daemon --import-snapshot path/to/1419120_2022_10_24T18_00_00Z.car.zst --halt-after-import
 ```
 
 With this command Lotus will import the snapshot and halt after the import process has finished. After the process has halted we can start the daemon and sync the remaining blocks.


### PR DESCRIPTION
Similar to #522.

In Lotus v1.20.0 users can import the snapshot without uncompressing it, so we can remove the uncompression part from the `Start-Lotus` page.