### PR TITLE
Update direct link to aws s3

### DIFF
--- a/content/en/lotus/developers/glif-nodes.md
+++ b/content/en/lotus/developers/glif-nodes.md
@@ -22,14 +22,14 @@ Unlike bare Lotus, the endpoint above is hardened and limited:
 - Only POST requests are supported.
 - The Filecoin signing tools can be used to sign messages before submission when needed.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
-- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json). `StateMarketDeals` data is refreshed every 10 minutes. Alternatively, you can query the Filecoin CID Checker Mongo DB via the [publicly available API](https://filecoin.tools/docs/static/index.html).
+- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes. Alternatively, you can query the Filecoin CID Checker Mongo DB via the [publicly available API](https://filecoin.tools/docs/static/index.html).
 - Mainnet network has a ws (web socket) endpoint. the ws link is available like [wss://wss.node.glif.io/apigw/lotus/rpc/v0](wss://wss.node.glif.io/apigw/lotus/rpc/v0)
 
 ## Testnet endpoint
 
 Testnet nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >}}) can use `https://api.calibration.node.glif.io/rpc/v0`.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
-- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json). `StateMarketDeals` data is refreshed every 10 minutes.
+- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes.
 
 - {{< alert icon="tip" >}}
 You can use the `v1` JSON RPC API with `https://api.calibration.node.glif.io/rpc/v1`
@@ -37,17 +37,17 @@ You can use the `v1` JSON RPC API with `https://api.calibration.node.glif.io/rpc
 
 - Testnet network has a ws (web socket) endpoint. the ws link is available like [wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0](wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0)
 
-## Wallaby endpoint
+## Hyperspace endpoint
 
-Wallaby nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >}}) can use `https://wallaby.node.glif.io/rpc/v0`.
+Hyperspace nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >}}) can use `https://hyperspace.node.glif.io/rpc/v0`.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
-- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-wallaby.s3.amazonaws.com/StateMarketDeals.json). `StateMarketDeals` data is refreshed every 10 minutes.
+- `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-hyperspace.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes.
 
 - {{< alert icon="tip" >}}
-You can use the `v1` JSON RPC API with `https://wallaby.node.glif.io/rpc/v1`
+You can use the `v1` JSON RPC API with `https://hyperspace.node.glif.io/rpc/v1`
 {{< /alert >}}
 
-- Wallaby network has a ws (web socket) endpoint. the ws link is available like [wss://wss.wallaby.node.glif.io/apigw/lotus/rpc/v0](wss://wss.wallaby.node.glif.io/apigw/lotus/rpc/v0)
+- Hyperspace network has a ws (web socket) endpoint. the ws link is available like [wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0](wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v0)
 
 ### Custom endpoints
 


### PR DESCRIPTION
Updated links for s3  

https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json --->.  https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst