### PR TITLE
Make it clearer arg should be minerID

### DIFF
--- a/content/en/storage-providers/operate/addresses.md
+++ b/content/en/storage-providers/operate/addresses.md
@@ -105,7 +105,7 @@ Approved By Nominee:    false
 For the change to take effect, the proposed new beneficiary address needs to confirm the proposal:
 
 ```shell with-output
-lotus-miner actor confirm-change-beneficiary --new-beneficiary=true <minerAddress>
+lotus-miner actor confirm-change-beneficiary --new-beneficiary=true <minerID>
 ```
 ```
 Confirming Pending Beneficiary Term of:


### PR DESCRIPTION
Make it clearer that arg should be minerID in the `lotus-miner actor confirm-change-beneficiary` cmd

