### PR TITLE
Shift weights operates menu

### DIFF
--- a/content/en/storage-providers/operate/lotus-miner-cli.md
+++ b/content/en/storage-providers/operate/lotus-miner-cli.md
@@ -7,7 +7,7 @@ menu:
     storage-providers:
         parent: "storage-providers-operate"
         identifier: "storage-provider-lotus-miner-cli"
-weight: 375
+weight: 390
 toc: true
 ---
 

--- a/content/en/storage-providers/operate/snap-deals/index.md
+++ b/content/en/storage-providers/operate/snap-deals/index.md
@@ -8,7 +8,7 @@ menu:
         parent: "storage-providers-operate"
 aliases:
     - /storage-providers/configure/snap-deals/
-weight: 390
+weight: 375
 toc: true
 ---
 


### PR DESCRIPTION
Shift the weights on the operates menu to get Lotus-Miner CLI page at the bottom of it.