### PR TITLE
fix: Move/deprecate connectivity sections

### DIFF
--- a/content/en/kb/legacy-miner-connectivety/index.md
+++ b/content/en/kb/legacy-miner-connectivety/index.md
@@ -17,7 +17,7 @@ areas: ["Deprecated"]
 ---
 
 {{< alert icon="warning" >}}
- The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0).
+ The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users to migrate to [Boost](https://boost.filecoin.io).
  {{< /alert >}}
 
 Filecoin miners, like participants in all peer-to-peer protocols, require a steady and quality pool of peers to communicate with in order to perform their various functions. This complements the [connectivity section]({{< relref "initialize#connectivity-to-the-miner" >}}) in the setup instructions and the [seal workers]({{< relref "seal-workers" >}}) guide.

--- a/content/en/kb/legacy-miner-connectivety/index.md
+++ b/content/en/kb/legacy-miner-connectivety/index.md
@@ -17,7 +17,7 @@ areas: ["Deprecated"]
 ---
 
 {{< alert icon="warning" >}}
- The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users to migrate to [Boost](https://boost.filecoin.io).
+ The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users migrate to [Boost](https://boost.filecoin.io).
  {{< /alert >}}
 
 Filecoin miners, like participants in all peer-to-peer protocols, require a steady and quality pool of peers to communicate with in order to perform their various functions. This complements the [connectivity section]({{< relref "initialize#connectivity-to-the-miner" >}}) in the setup instructions and the [seal workers]({{< relref "seal-workers" >}}) guide.

--- a/content/en/kb/legacy-miner-connectivety/index.md
+++ b/content/en/kb/legacy-miner-connectivety/index.md
@@ -1,17 +1,24 @@
 ---
-title: "Connectivity"
-description: "This guide shows tips and tricks to improve miner connectivity."
-lead: "This guide shows tips and tricks to improve miner connectivity."
+title: "Legacy lotus-miner markets connectivety"
+description: "This guide shows connectivety tips and tricks for the legacy lotus-miner markets"
+date: 2023-05-16T12:00:35+01:00
+lastmod: 2023-05-16T12:00:35+01:00
 draft: false
 menu:
-    storage-providers:
-        parent: "storage-providers-operate"
-        identifier: "storage-provier-connectivity"
+  kb:
+    parent: "browse"
 aliases:
     - /docs/storage-providers/connectivity/
-weight: 320
-toc: true
+    - /storage-providers/operate/connectivity/
+toc: false
+pinned: false
+types: ["article"]
+areas: ["Deprecated"]
 ---
+
+{{< alert icon="warning" >}}
+ The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0).
+ {{< /alert >}}
 
 Filecoin miners, like participants in all peer-to-peer protocols, require a steady and quality pool of peers to communicate with in order to perform their various functions. This complements the [connectivity section]({{< relref "initialize#connectivity-to-the-miner" >}}) in the setup instructions and the [seal workers]({{< relref "seal-workers" >}}) guide.
 

--- a/content/en/storage-providers/setup/initialize.md
+++ b/content/en/storage-providers/setup/initialize.md
@@ -47,20 +47,6 @@ lotus-miner init --owner=<address>  --worker=<needs-bls-address> --no-local-stor
 - The `--no-local-storage` flag is used so that we can later configure [specific locations for storage]({{< relref "../../storage-providers/operate/custom-storage-layout/" >}}) the location of our sealing storage, and our long term storage.
 - The `--sector-size` specifies the sector size, and can not be changed after the init. The default is 32GiB.
 
-## Connectivity to the storage provider
-
-Before you run your storage provider, it is important that it is reachable from any peer in the Filecoin network. For this, you will need a stable public IP and edit your `~/.lotusminer/config.toml` as follows:
-
-```toml
-...
-[Libp2p]
-  ListenAddresses = ["/ip4/0.0.0.0/tcp/24001"] # choose a fixed port
-  AnnounceAddresses = ["/ip4/<YOUR_PUBLIC_IP_ADDRESS>/tcp/24001"] # important!
-...
-```
-
-Once you start your storage provider, [make sure you can connect to its public IP/port]({{< relref "../../storage-providers/operate/connectivity/" >}}).
-
 ## Running the storage provider
 
 You are now ready to start the `lotus-miner` process:
@@ -73,18 +59,6 @@ or if you are using the systemd service file:
 
 ```shell
 systemctl start lotus-miner
-```
-
-{{< alert icon="warning" >}}
-**Do not proceed** from here until you have verified that your storage provider not only is running, but also [reachable on its public IP address]({{< relref "../../storage-providers/operate/connectivity/" >}}).
-{{< /alert >}}
-
-## Publishing the addresses
-
-Once the storage provider is up and running, publish your address (which you configured above) to the chain so that other nodes can talk to it directly and make deals:
-
-```shell
-lotus-miner actor set-addrs /ip4/<YOUR_PUBLIC_IP_ADDRESS>/tcp/24001
 ```
 
 ## Next steps

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -219,36 +219,10 @@ This section will cover the installation, configuration, and how to start the lo
     lotus-miner init --owner=<address>  --worker=<address> --no-local-storage
     ```
 
-1. Configure libp2p port in the `~/.lotusminer/config.toml` file so miner other nodes can find the miner in the network:
-    
-    ```shell
-    ...
-    [Libp2p]
-      ListenAddresses = ["/ip4/0.0.0.0/tcp/24001"] # choose a fixed port
-      AnnounceAddresses = ["/ip4/B.B.B.B/tcp/24001"] # important!
-    ...
-    ```
-    
-    Choosing port `0.0.0.0` on `ListenAddress` allows the miner process to listen on both internal interfaces `x.x.x.x` and `B.B.B.B`. But we are announcing only the public address so all connections coming from the network are routed via this address.
-
 1. Start the miner
     
     ```shell
     lotus-miner run
-    ```
-
-1. Test that your miner is reachable at its public address. Go through the [connectivity guide]({{<relref "../../storage-providers/operate/connectivity" >}}) in case you need more information about this. Please do not proceed with the next step if your miner is not reachable:
-    
-    ```shell
-    $ lotus-miner net reachability
-    AutoNAT status:  Public
-    Public address:  /ip4/<IP>/tcp/<port>
-    ```
-
-1. Publish your miner address in the network:
-    
-    ```shell
-    lotus-miner actor set-addrs /ip4/B.B.B.B/tcp/24001
     ```
 
 ### Lotus miner configuration


### PR DESCRIPTION
As part of the #492

- Move the connectivity page to the knowledge base with notice to use Boost
- Remove connectivity settings during setup, as no-markets lotus-miner nodes does not have networking.