### PR TITLE
Adjust link in lotus/storage-providers/get-started

### DIFF
--- a/content/en/storage-providers/get-started/overview/index.md
+++ b/content/en/storage-providers/get-started/overview/index.md
@@ -13,7 +13,7 @@ weight: 105
 toc: true
 ---
 
-This section contains guides to initialize and run a successful storage provider operation using Lotus and should be approached by **advanced users only**. You should read through and be familiar with the concepts outlined in these two articles: [how Filecoin works](https://docs.filecoin.io/basics/what-is-filecoin/overview/), [how mining works](https://docs.filecoin.io/storage-provider/how-providing-works/), as well as having a Lotus node running.
+This section contains guides to initialize and run a successful storage provider operation using Lotus and should be approached by **advanced users only**. You should read through and be familiar with the concepts outlined in the [Becoming a storage provider guide](https://docs.filecoin.io/storage-provider/basics/overview/), as well as having a Lotus node running.
 
 ![High Level Full Lotus System](High-Level-Full-Lotus-System.png)
 


### PR DESCRIPTION
Closes: #634 

Adjust links in lotus/storage-providers/get-started to link to the Becoming a storage provider guide in the Filecoin docs.