### PR TITLE
chore: Fix description typo

### DIFF
--- a/content/en/lotus/manage/lotus-cli.md
+++ b/content/en/lotus/manage/lotus-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "CLI"
 description: "Reference documentation for the Lotus command-line interface."
-lead: "Reference documentation for the Lotus command-line interface. This documentation was automatically generated using Lotus v1.23.1."
+lead: "Reference documentation for the Lotus command-line interface. This documentation was automatically generated using Lotus v1.23.3."
 draft: false
 menu:
     lotus:

--- a/content/en/storage-providers/operate/lotus-miner-cli.md
+++ b/content/en/storage-providers/operate/lotus-miner-cli.md
@@ -1,7 +1,7 @@
 ---
 title: "Lotus-miner CLI"
 description: "Reference documentation for the lotus-miner command-line interface."
-lead: "Reference documentation for the lotus-miner command-line interface. This documentation was automatically generated using Lotus v1.23.1."
+lead: "Reference documentation for the lotus-miner command-line interface. This documentation was automatically generated using Lotus v1.23.3."
 draft: false
 menu:
     storage-providers:


### PR DESCRIPTION
The description says that the version is v1.23.1, but the CLI-reference documentation is from Lotus v1.23.3