### PR TITLE
nv21: remove renew cmd for nv21

### DIFF
--- a/content/en/storage-providers/operate/daily-chores.md
+++ b/content/en/storage-providers/operate/daily-chores.md
@@ -40,10 +40,6 @@ ID  SealProof  InitialPledge  Activation                      Expiration        
 
 ## Extend sectors
 
-{{< alert icon="warning" >}}
-Please note that for the Lotus v1.22.1 both the `lotus-miner sectors extend` and `lotus-miner sectors renew` commands exists. In this guide we explain how to extend sectors in Lotus v1.23.0 or higher.
-{{< /alert >}}
-
 You can extend the lifecycle of a sector with the `lotus-miner sectors extend` command:
 
 ```shell


### PR DESCRIPTION
Since nv21 is based off Lotus v1.23.3 or higher, `lotus-miner sectors renew` is not a relevant command after the upgrade.