### PR TITLE
command line error on extract

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -65,7 +65,7 @@ sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.
 1. Extract tar -xvf archive.tar.gz executable:
 
     ```shell
-    tar -xvf lotus_1.22.1_linux_amd64.tar.gz
+    tar -xvf lotus_v1.22.1_linux_amd64.tar.gz
     ```
 
 1. Move the `lotus` binary to `/usr/local/bin`:


### PR DESCRIPTION
Where the name of the tarball is lotus_v1.22.1_linux_amd64.tar.gz  and the next commands are missing the v in v1.22.1 so won't find it.