### PR TITLE
Chore: Move Market config page to kb

### DIFF
--- a/content/en/kb/legacy-markets-config/index.md
+++ b/content/en/kb/legacy-markets-config/index.md
@@ -7,6 +7,8 @@ draft: false
 menu:
   kb:
     parent: "browse"
+aliases:
+    - /storage-providers/advanced-configurations/market/
 toc: false
 pinned: false
 types: ["article"]
@@ -64,14 +66,6 @@ The final value of `ExpectedSealDuration` should equal `(TIME_TO_SEAL_A_SECTOR +
 `StartEpochSealingBuffer` allows `lotus-miner` to seal a sector before a certain epoch. For example: if the current epoch is 1000 and a deal within a sector must start on epoch 1500, then `lotus-miner` must wait until the current epoch is 1500 before it can start sealing that sector. However, if `lotus-miner` sets `StartEpochSealingBuffer` to 500, the `lotus-miner` can start sealing the sector at epoch 1000. 
 
 If there are multiple deals in a sector, the deal with a start time closest to the current epoch is what `StartEpochSealingBuffer` will be based off. So, if the sector in our example has three deals that start on epoch 1000, 1200, and 1400, then we `lotus-miner` will start sealing the sector at epoch 500.
-
-### Disabling new sector for deal
-
-If `MakeNewSectorForDeals` is set to `true` then `lotus-miner` will create new sectors for incoming deals. This option can set to `false` to ensure that all new deals are sealed as snap-deals into CC sectors. This can help reduce the sealing time for the new deals as long as CC sectors are ready for the snap-deals.
-
-### Make new CC sector available for snap-deal
-
-`MakeCCSectorsAvailable` makes all the new CC sectors available to be upgraded with snap-deals. When this boolean is set to `true`, all pledged "CC" sectors from that point onwards will be converted to "Available" state after sealing. This enables sealing the incoming storage deals more quickly into these "Available" sectors compared to creating a new sector for the deals. 
 
 ### Publishing several deals in one message
 

--- a/content/en/kb/legacy-markets-config/index.md
+++ b/content/en/kb/legacy-markets-config/index.md
@@ -1,14 +1,21 @@
 ---
-title: "Market"
-description: "Lotus has a lot of advanced configurations you can tune to optimize your storage provider setup. This guide explains the advanced configuration options for lotus market"
-lead: "Lotus has a lot of advanced configurations you can tune to optimize your storage provider setup. This guide explains the advanced configuration options for lotus market"
+title: "Lotus-miner legacy markets Configs"
+description: "The Lotus-Miner Legacy Markets are deprecated. This is an overview of its configs."
+date: 2023-10-27T12:00:35+01:00
+lastmod: 2023-10-27T12:00:35+01:00
 draft: false
 menu:
-    storage-providers:
-        parent: "storage-providers-advanced-configurations"
-weight: 510
-toc: true
+  kb:
+    parent: "browse"
+toc: false
+pinned: false
+types: ["article"]
+areas: ["Deprecated"]
 ---
+
+{{< alert icon="warning" >}}
+The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0). We recommend our users migrate to [Boost](https://boost.filecoin.io).
+{{< /alert >}}
 
 ## Dealmaking section
 

--- a/content/en/kb/legacy-markets-config/index.md
+++ b/content/en/kb/legacy-markets-config/index.md
@@ -1,8 +1,8 @@
 ---
 title: "Lotus-miner legacy markets Configs"
 description: "The Lotus-Miner Legacy Markets are deprecated. This is an overview of its configs."
-date: 2023-10-27T12:00:35+01:00
-lastmod: 2023-10-27T12:00:35+01:00
+date: 2023-10-26T12:00:35+01:00
+lastmod: 2023-10-26T12:00:35+01:00
 draft: false
 menu:
   kb:

--- a/content/en/storage-providers/advanced-configurations/sealing.md
+++ b/content/en/storage-providers/advanced-configurations/sealing.md
@@ -454,3 +454,10 @@ Set the maximum cost you are willing to pay for onboarding **per** sector in `Ma
 The current `MaxCommitBatchGasFee.PerSector` is enough to aggregate proofs for 6 sectors. Adjust this respectively according to your operation. **If the value is too low, the message may wait in the mempool for a long while. If you don't have enough funds, the message will not be sent.**
 {{< /alert >}}
 
+### Make new CC sector available for snap-deal
+
+`MakeCCSectorsAvailable` makes all the new CC sectors available to be upgraded with snap-deals. When this boolean is set to `true`, all pledged "CC" sectors from that point onwards will be converted to "Available" state after sealing. This enables sealing the incoming storage deals more quickly into these "Available" sectors compared to creating a new sector for the deals. 
+
+### Disabling new sector for deal
+
+If `MakeNewSectorForDeals` is set to `true` then `lotus-miner` will create new sectors for incoming deals. This option can set to `false` to ensure that all new deals are sealed as snap-deals into CC sectors. This can help reduce the sealing time for the new deals as long as CC sectors are ready for the snap-deals.

--- a/content/en/storage-providers/operate/snap-deals/index.md
+++ b/content/en/storage-providers/operate/snap-deals/index.md
@@ -200,7 +200,7 @@ A new feature in `lotus-miner` allows converting all the future "CC" sectors to 
 1. It removes the manual intervention required to convert the "CC" sectors to snap-deal ready sectors and thus, reduces the overhead for the storage provider. 
 2. As all the new storage deals will be sealed as part of snap-deal, the sealing time would be considerable less.
 
-This new feature can be enabled in the lotus miner [configuration]({{<relref "../../advanced-configurations/    sealing#make-new-cc-sector-available-for-snap-deal">}}).
+This new feature can be enabled in the lotus miner [configuration]({{<relref "../../advanced-configurations/sealing#make-new-cc-sector-available-for-snap-deal">}}).
 
 When a deal enters the the sealing pipeline, lotus-miner will try to match it to any sectors waiting for deals before sealing. If none are found then, lotus-miner will try to check if any `Available` sectors can accept it. It will select a candidate with the lowest initial pledge. If none of the sectors are eligible then a new sector can be created based on the value of `MakeNewSectorForDeals` under [configuration]({{<relref "../../advanced-configurations/sealing#disabling-new-sector-for-deal">}}). 
 

--- a/content/en/storage-providers/operate/snap-deals/index.md
+++ b/content/en/storage-providers/operate/snap-deals/index.md
@@ -200,9 +200,9 @@ A new feature in `lotus-miner` allows converting all the future "CC" sectors to 
 1. It removes the manual intervention required to convert the "CC" sectors to snap-deal ready sectors and thus, reduces the overhead for the storage provider. 
 2. As all the new storage deals will be sealed as part of snap-deal, the sealing time would be considerable less.
 
-This new feature can be enabled in the lotus miner [configuration]({{<relref "../../advanced-configurations/market#make-new-cc-sector-available-for-snap-deal">}}).
+This new feature can be enabled in the lotus miner [configuration]({{<relref "../../advanced-configurations/    sealing#make-new-cc-sector-available-for-snap-deal">}}).
 
-When a deal enters the the sealing pipeline, lotus-miner will try to match it to any sectors waiting for deals before sealing. If none are found then, lotus-miner will try to check if any `Available` sectors can accept it. It will select a candidate with the lowest initial pledge. If none of the sectors are eligible then a new sector can be created based on the value of `MakeNewSectorForDeals` under [configuration]({{<relref "../../advanced-configurations/market#disabling-new-sector-for-deal">}}). 
+When a deal enters the the sealing pipeline, lotus-miner will try to match it to any sectors waiting for deals before sealing. If none are found then, lotus-miner will try to check if any `Available` sectors can accept it. It will select a candidate with the lowest initial pledge. If none of the sectors are eligible then a new sector can be created based on the value of `MakeNewSectorForDeals` under [configuration]({{<relref "../../advanced-configurations/sealing#disabling-new-sector-for-deal">}}). 
 
 {{< alert >}}
 In the case that creating new sectors for deals is disabled, the deal will be left hanging until a sector is made "Available" for it.


### PR DESCRIPTION
Closes: #602

- Move the legacy lotus-miner market config page to the kb.
   - Add that this section is deprecated.
- Move SnapDeal-configs to sealing section, as they where wrongly misplaced in the market config page.