### PR TITLE
fix: Remove `fvm_concurrency` warning

### DIFF
--- a/content/en/lotus/configure/Ethereum RPC.md
+++ b/content/en/lotus/configure/Ethereum RPC.md
@@ -104,7 +104,7 @@ By default, the `eth_rpc` API is available at `http://127.0.0.1:1234/rpc/v1`.
 
 ### Environment variables
 
-- `LOTUS_FVM_CONCURRENCY`: Users with higher available memory can experiment with setting LOTUS_FVM_CONCURRENCY to higher values, up to 48, to allow for more concurrent FVM execution. Please note that this value should not be set to higher then 24 during a network upgrade!
+- `LOTUS_FVM_CONCURRENCY`: Users with higher available memory can experiment with setting LOTUS_FVM_CONCURRENCY to higher values, up to 48, to allow for more concurrent FVM execution.
 - `LOTUS_FEVM_ENABLEETHRPC`: Enables the Eth RPC feature and allows storing a mapping of Eth transaction hashes to Filecoin message CIDs.
 - `LOTUS_FEVM_ETHTXHASHMAPPINGLIFETIMEDAYS`: The number of days after which a transaction hash lookup database will delete mappings that have been stored.
 - `LOTUS_FEVM_EVENTS_DISABLEREALTIMEFILTERAPI` : Disables the RealTimeFilterAPI that can create and query filters for actor events as they are emitted. 


### PR DESCRIPTION
Remove fvm_concurrency warning. As this has been fixed.