### PR TITLE
Update macos.md

### DIFF
--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -82,7 +82,7 @@ We recommend that macOS users use [Homebrew](https://brew.sh) to install each of
 1. Use the command `brew install` to install the following packages:
 
    ```shell
-   brew install go bzr jq pkg-config hwloc coreutils
+   brew install go bzt jq pkg-config hwloc coreutils
    ```
 
 Next up is cloning the Lotus repository and building the executables.


### PR DESCRIPTION
```
brew install bzr
==> Downloading https://formulae.brew.sh/api/formula.jws.json ################################################################################################################# 100.0%

 ==> Downloading https://formulae.brew.sh/api/cask.jws.json ################################################################################################################# 100.0% 
 
 Warning: No available formula with the name "bzr". Did you mean bzt, bar or dzr? 
 
 ==> Searching for similarly named formulae and casks... ==> Formulae
bzt ✔                                   bar                                     dzr

To install bzt ✔, run:
  brew install bzt ✔
```

--

bzt did the trick, though not even sure its required, but confident that bzr is not a thing...