### PR TITLE
Bump minimum Go-version needed

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -126,10 +126,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ### Go
 
-To build Lotus, you need a working installation of [Go 1.20.7 or higher](https://golang.org/dl/):
+To build Lotus, you need a working installation of [Go 1.21.7 or higher](https://golang.org/dl/):
 
 ```shell
-wget -c https://golang.org/dl/go1.20.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+wget -c https://golang.org/dl/go1.21.7.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
 ```
 
 {{< alert icon="tip">}}

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -25,7 +25,7 @@ Before we get started, let's just go over the terms we'll use in this guide:
 To spin up a Lotus lite-node, you will need:
 
 1. A Lotus node - For best results, make sure that this node is fully synced.
-2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.20.7 or higher installed.
+2. A computer with at least 2GB RAM and a dual-core CPU to act as the Lotus lite-node. This can be your local machine. This computer must have Rust and Go 1.21.7 or higher installed.
 3. You must have all the software dependencies required to build Lotus.
 
 ## Full-node preparation


### PR DESCRIPTION
The minimum Go-version supported for the upcoming mandatory release (v1.26.0), will be Go v1.21.7. 

Updating the docs here. Wait to merge until final release has been cut (March 21st)