### PR TITLE
202406 doc cleanups

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -14,15 +14,15 @@ titleHome = "Lotus Docs"
 
 ## Twitter Cards
 twitterSite = "@filecoin"
-twitterCreator = "@protocollabs"
+twitterCreator = "@_FilOz"
 
 ## JSON-LD
 # schemaType = "Person"
 schemaType = "Organization"
 schemaName = "Lotus"
-schemaAuthor = "Protocol Labs"
-schemaAuthorTwitter = "https://twitter.com/protocollabs"
-schemaAuthorLinkedIn = "https://www.linkedin.com/in/protocollabs/"
+schemaAuthor = "FilOz"
+schemaAuthorTwitter = "https://x.com/_FilOz"
+schemaAuthorLinkedIn = "https://www.linkedin.com/company/filoz/"
 schemaAuthorGitHub = "https://github.com/filecoin-project"
 schemaLocale = "en-US"
 schemaLogo = "lotus.png"
@@ -50,8 +50,8 @@ portraitPhotoWidths = [800, 700, 600, 500]
 lqipWidth = "20x"
 
 # Footer
-footer = "Built by Protocol Labs."
-footer_link = "https://protocol.ai"
+footer = "Developed and Maintained by FilOz."
+footer_link = "https://filoz.org"
 
 # Feed
 copyRight = ""

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,7 +1,7 @@
 ---
 title : "Lotus"
-description: "Lotus is the reference implementation for the Filecoin network. It is written in Go, and is maintained by the Protocol Labs team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!"
-lead: "Lotus is the reference implementation for the Filecoin network. It is written in Go, and is maintained by the Protocol Labs team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!"
+description: "Lotus is the reference implementation for the Filecoin network. It is written in Go.  It was originally developed at Protocol Labs and is now maintained by the FilOz team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!"
+lead: "Lotus is the reference implementation for the Filecoin network. It is written in Go.  It was originally developed at Protocol Labs and is now maintained by the FilOz team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!"
 draft: false
 images: []
 ---

--- a/content/en/lotus/configure/bootstrap/index.md
+++ b/content/en/lotus/configure/bootstrap/index.md
@@ -18,7 +18,7 @@ toc: true
 Joining the Filecoin network requires knowledge of existing peers in the network. On startup Lotus, as well as other
 implementations, attempt to retrieve peer information from a known set of bootstrap nodes.
 
-At present, these known bootstrap nodes are [included in](https://github.com/filecoin-project/lotus/blob/c46aea6a368bbebf4a22e9924a3ea3393170fe90/build/bootstrap/mainnet.pi) Lotus releases, but the list is also configurable at runtime.
+At present, these known bootstrap nodes are [included in](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi) Lotus releases, but the list is also configurable at runtime.
 
 Lotus is currently the only known filecoin implementation offering bootstrap functionality.
 

--- a/content/en/lotus/configure/bootstrap/index.md
+++ b/content/en/lotus/configure/bootstrap/index.md
@@ -34,20 +34,14 @@ While it’s possible to synchronise a Lotus node with relatively low resources,
 marginally more resources, it’s important to ensure that a bootstrap node is able to stay synchronised with the
 network while also serving an unpredictable number of bootstrap requests.
 
-We currently run bootstrap nodes on the following hardware
-
-- Intel Xeon Platinum 8175M CPU @ 2.50GHz
-- 32Gb Memory
-- 5Mbps download speed, 2Mbps upload speed
-- 2Ti SSD storage for chain state storage
-
 It’s possible to reliably synchronise a bootstrap node with as few as 3 cores and 5Gb real memory, but you will need
 to monitor resource usage closely in periods of high demand, and account for additional disk space for virtual memory.
 
-To demonstrate the resource requirements of a bootstrap node, see the last 7 days (ATOW) cpu and memory profile of one
-(out of 9) bootstrap nodes on the network.
+To demonstrate the resource requirements of a bootstrap node, see a 7 day window of cpu and memory profiles of one
+bootstrap node on the network.
 ![7 Day CPU core usage profile](7d-cpu.png "7 Day CPU profile")
 ![7 Day Memory profile](7d-memory.png "7 Day Memory profile")
+
 ## Configuration
 We recommend the following configuration to be specified for running a bootstrap node.
 ```toml

--- a/content/en/lotus/configure/defaults.md
+++ b/content/en/lotus/configure/defaults.md
@@ -419,7 +419,7 @@ The Lotus daemon stores a configuration file in `~/.lotus/config.toml`. Note tha
 
 ## Connectivity
 
-Usually your lotus daemon will establish connectivity with others in the network and try to make itself diallable using uPnP. If you wish to manually ensure that your daemon is reachable:
+Usually your lotus daemon will establish connectivity with others in the network and try to make itself diallable using UPnP. If you wish to manually ensure that your daemon is reachable:
 
 - Set a fixed port of your choice in the `ListenAddresses` in the Libp2p section (i.e. 6665).
 - Open a port in your router that is forwarded to this port. This is usually called featured as "Port forwarding" and the instructions differ from router model to model but there are many guides online.

--- a/content/en/lotus/developers/contribute.md
+++ b/content/en/lotus/developers/contribute.md
@@ -50,6 +50,3 @@ Filecoin is ultimately about building better protocols, and we always welcome id
 
 - [filecoin-project/specs](https://github.com/filecoin-project/specs)
 
-## Research
-
-Finally, we see Protocol Labs as a research lab, where YOUR ideas can become technologies that have a real impact on the world. If you're interested in contributing to our research, please reach out to [research@protocol.ai](mailto:research@protocol.ai) for more information. Include what your interests are so we can make sure you get to work on something fun and valuable.

--- a/content/en/lotus/developers/contribute.md
+++ b/content/en/lotus/developers/contribute.md
@@ -19,22 +19,26 @@ Lotus, the reference implementation of Filecoin and its sister-projects are big,
 The biggest and most active repositories we have today are:
 
 - [filecoin-project/lotus](https://github.com/filecoin-project/lotus)
+- [filecoin-project/builtin-actors](https://github.com/filecoin-project/builtin-actors)
+- [filecoin-project/ref-fvm](https://github.com/filecoin-project/ref-fvm)
 - [filecoin-project/rust-fil-proofs](https://github.com/filecoin-project/rust-fil-proofs)
 
-If you want to start contributing to the core of Filecoin, those repositories are a great place start. But the _Help Wanted_ label exists in several related projects:
+If you want to start contributing to the core of Filecoin, those repositories are a great place start. 
+
+But the _Help Wanted_ label also exists in several related projects:
 
 - [IPFS](https://github.com/ipfs)
 - [libp2p](https://github.com/libp2p)
-- [IPLD](https://github.com/libp2p)
+- [IPLD](https://github.com/ipld)
 - [Multiformats](https://github.com/multiformats)
 
 ## Community
 
 The Filecoin community is active and here to answer your questions in your channel of choice.
 
-For shorter-lived discussions, our community chat is open to all on both [Slack](https://filecoin.io/slack/)
+For shorter-lived discussions, our community chat is open to all on [Slack](https://filecoin.io/slack/) in the #fil-lotus-dev channel.
 
-For long-lived discussions and for support, please use the [discussion tab on GitHub](https://github.com/filecoin-project/lotus/discussions) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.
+For long-lived discussions and for support, please use [Lotus GitHub discussions](https://github.com/filecoin-project/lotus/discussions) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.
 
 ## Build Applications
 
@@ -48,5 +52,6 @@ Get started by looking at the list of projects currently built on Filecoin. Buil
 
 Filecoin is ultimately about building better protocols, and we always welcome ideas and feedback on how to improve those protocols.
 
+- [filecoin-project/FIPs](https://github.com/filecoin-project/FIPs)
 - [filecoin-project/specs](https://github.com/filecoin-project/specs)
 

--- a/content/en/lotus/developers/glif-nodes.md
+++ b/content/en/lotus/developers/glif-nodes.md
@@ -14,7 +14,7 @@ toc: true
 
 ## Mainnet endpoint
 
-Developers can interact directly with load-balanced, synced mainnet nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >}}) on the `https://api.node.glif.io` endpoint (or `https://api.node.glif.io/rpc/v0`).
+Developers can interact directly with load-balanced, synced mainnet nodes using the [Lotus JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) on the `https://api.node.glif.io` endpoint (or `https://api.node.glif.io/rpc/v0`).
 
 Unlike bare Lotus, the endpoint above is hardened and limited:
 
@@ -23,11 +23,11 @@ Unlike bare Lotus, the endpoint above is hardened and limited:
 - The Filecoin signing tools can be used to sign messages before submission when needed.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
 - `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes. Alternatively, you can query the Filecoin CID Checker Mongo DB via the [publicly available API](https://filecoin.tools/docs/static/index.html).
-- Mainnet network has a ws (web socket) endpoint. the ws link is available like [wss://wss.node.glif.io/apigw/lotus/rpc/v0](wss://wss.node.glif.io/apigw/lotus/rpc/v0)
+- Mainnet network has a ws (web socket) endpoint. The WebSockets link is available at wss://wss.node.glif.io/apigw/lotus/rpc/v0
 
-## Testnet endpoint
+## Calibration endpoint
 
-Testnet nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >}}) can use `https://api.calibration.node.glif.io/rpc/v0`.
+Calibration nodes using the [JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) can use `https://api.calibration.node.glif.io/rpc/v0`.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
 - `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes.
 
@@ -35,7 +35,7 @@ Testnet nodes using the [JSON RPC API]({{< relref "/reference/basics/overview" >
 You can use the `v1` JSON RPC API with `https://api.calibration.node.glif.io/rpc/v1`
 {{< /alert >}}
 
-- Testnet network has a ws (web socket) endpoint. the ws link is available like [wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0](wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0)
+- The Calibration network has a WebSocket endpoint. The WebSlock link is available at wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0
 
 ### Custom endpoints
 
@@ -65,7 +65,7 @@ This is an optional step. We can use `lotus` to talk to the Glif node API (as a 
 - It allows us to verify that the endpoint works and that credentials are correct when using a custom endpoint.
 - It makes debugging easier was we can try and quickly check things using the `lotus` CLI directly.
 
-To use `lotus`, download and extract the appropriate lotus release from the [releases page](https://github.com/filecoin-project/lotus/releases/). **The lotus version needs to match that of the running node**. We will not be running the Lotus daemon or syncing the chain, we will use it only as a client.
+To use `lotus`, build or install lotus for [Linux]({{< relref "../install/linux" >}}) or [MacOS]({{< relref "../install/macos" >}}). **The lotus version needs to match that of the running node**. We will not be running the Lotus daemon or syncing the chain; we will use it only as a client.
 
 Check the running version of the Glif node instance with:
 
@@ -73,7 +73,7 @@ Check the running version of the Glif node instance with:
 curl -X POST 'https://api.node.glif.io' -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"Filecoin.Version","params":[]}'
 ```
 
-Once downloaded, in order to let the Lotus binary talk to the Lotus remote endpoint, export the following environment variable:
+Once built or installed, in order to let the Lotus binary talk to the Lotus remote endpoint, export the following environment variable:
 
 ```shell
 export FULLNODE_API_INFO=<token>:<endpoint>
@@ -90,7 +90,7 @@ lotus net id 12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt
 
 If the above does not work, verify that you are using the right token and multiaddress.
 
-By default, all read operations are enabled, along with the MPoolPush method. This means that you will need to [sign messages yourself](https://docs.filecoin.io/build/signing-libraries/) using your own externally-managed wallets, unless you are given a full node under your full control. We can however, use the CLI to send any read commands. The following are just examples:
+By default, all read operations are enabled, along with the MPoolPush method. This means that you will need to [sign messages yourself](https://docs.filecoin.io/reference/general#message-signing-tools) using your own externally-managed wallets, unless you are given a full node under your full control. We can however, use the CLI to send any read commands. The following are just examples:
 
 ```shell
 ./lotus net id
@@ -106,7 +106,7 @@ Get familiar with the capabilities of your node and verify that the endpoints. T
 
 Your application will very probably interact with the Lotus JSON-RPC API directly. Here are the first steps to gain operative knowledge on this API:
 
-- Read the instructions in the [Lotus API reference](https://docs.filecoin.io/build/signing-libraries/). Understand how calls are performed, how authentication works and how parameters and responses are encoded in JSON-RPC. Try out some `curl` examples.
+- Read the instructions in the [Lotus API reference](https://docs.filecoin.io/reference/json-rpc). Understand how calls are performed, how authentication works and how parameters and responses are encoded in JSON-RPC. Try out some `curl` examples.
 - From the above, learn how to obtain the parameters and expected format for every endpoint from the Lotus Go documentation. This will be the first place to check if something does not work or the format of some parameter is not understood.
 - You can also use this [Lotus API documentation](https://documenter.getpostman.com/view/4872192/SWLh5mUd?version=latest) which covers the Glif Node-supported methods in a more readable form, with additional tips.
-- If you are planning to send transactions, you will need to manage wallets and create signatures for your messages. See the [signing libraries](https://docs.filecoin.io/build/signing-libraries/) page for different solutions.
+- If you are planning to send transactions, you will need to manage wallets and create signatures for your messages. See the [signing libraries](https://docs.filecoin.io/reference/general#message-signing-tools) page for different solutions.

--- a/content/en/lotus/get-started/networks.md
+++ b/content/en/lotus/get-started/networks.md
@@ -42,14 +42,7 @@ Mainnet is the primary Filecoin network. Mainnet began on block 148,888. It supp
 
 **Bootstrap peers**:
 
-```
-/dns4/node.glif.io/tcp/1235/p2p/12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt
-/dns4/bootstarp-0.1475.io/tcp/61256/p2p/12D3KooWRzCVDwHUkgdK7eRgnoXbjDAELhxPErjHzbRLguSV1aRt
-/dns4/bootstrap-venus.mainnet.filincubator.com/tcp/8888/p2p/QmQu8C6deXwKvJP2D8B6QGyhngc3ZiDnFzEHBDx8yeBXST
-/dns4/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH
-/dns4/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ
-/dns4/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH
-```
+See https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi
 
 **Resources**:
 
@@ -93,12 +86,8 @@ Calibration network is the most realistic simulation of the Filecoin mainnet:
 
 **Bootstrap peers**:
 
-```
-/dns4/calibration.node.glif.io/tcp/1237/p2p/12D3KooWQPYouEAsUQKzvFUA9sQ8tz4rfpqtTzh2eL6USd9bwg7x
-/dns4/bootstrap-calibnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWABQ5gTDHPWyvhJM7jPhtNwNJruzTEo32Lo4gcS5ABAMm
-/dns4/bootstrap-calibnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWS3ZRhMYL67b4bD5XQ6fcpTyVQXnDe8H89LvwrDqaSbiT
-/dns4/bootstrap-calibnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48
-```
+See https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi
+
 **Resources**:
 
 - [Latest chain snapshot (lightweight)](https://forest-archive.chainsafe.dev/latest/calibnet/)

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -173,7 +173,7 @@ Once all the dependencies are installed, you can build and install Lotus.
     The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
 
-1. If you are in China, see "[Lotus: tips when running in China]({{< relref "" >}})".
+1. If you are in China, see "[Lotus: tips when running in China]({{< relref "../../kb/nodes-in-china/" >}})".
 1. Depending on your CPU model, you will want to export additional environment variables:
 
     a. If you have **an AMD Zen or Intel Ice Lake CPU (or later)**, enable the use of SHA extensions by adding these two environment variables:

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -172,7 +172,6 @@ Once all the dependencies are installed, you can build and install Lotus.
 
     The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
-
 1. If you are in China, see "[Lotus: tips when running in China]({{< relref "../../kb/nodes-in-china/" >}})".
 1. Depending on your CPU model, you will want to export additional environment variables:
 

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -40,18 +40,16 @@ If you are using the Protocol Labs `api.chain.love` Lotus full-node, you do not 
 If you are using a node-hosting service like [Infura](https://infura.io/), you may need to create an API key through the service website.
 {{< /alert >}}
 
-1. On your full-node open `~/.lotus/config` and:
+1. On your full-node: 
+    1. open `~/.lotus/config`
+    2. Uncomment line 3
+    3. Change `127.0.0.1` to `0.0.0.0`
+        ```toml
+        ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
+        ```
+    4. Save and exit the file
 
-    a. Uncomment line 3.
-    a. Change `127.0.0.1` to `0.0.0.0`.
-
-    ```toml
-    ListenAddress = "/ip4/0.0.0.0/tcp/1234/http"
-    ```
-
-    Save and exit the file.
-
-1. Create an API token for your lite-node to use:
+2. Create an API token for your lite-node to use:
 
     ```shell
     # lotus auth create-token --perm <read,write,sign,admin>
@@ -60,8 +58,8 @@ If you are using a node-hosting service like [Infura](https://infura.io/), you m
 
     Which permissions you choose will depend on your use case. Take a look at the [API tokens section to find out more →]({{< relref "reference/basics/api-access#api-tokens" >}})
 
-1. Send this API token to your lite-node or to whoever will be the administrator for the lite-node.
-1. If you have the `lotus daemon` running, stop it and start it again. This forces Lotus to open the API port we just set.
+3. Send this API token to your lite-node or to whoever will be the administrator for the lite-node.
+4. If you have the `lotus daemon` running, stop it and start it again. This forces Lotus to open the API port we just set.
 
 Next up, you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
 

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -33,9 +33,7 @@ To spin up a Lotus lite-node, you will need:
 If you have access to the full-node you're using, you need to make some minor modifications to its configuration.
 
 {{< alert icon="tip">}}
-If you are using the Protocol Labs `api.chain.love` Lotus full-node, you do not need to complete this section. The Protocol Labs Lotus full-node has been configured to accept all incoming requests, so you don't need to create any API keys.
-
-[Glif](https://api.node.glif.io/) endpoints also provide you with a production-ready publicly available node, that can be used without API keys: wss://wss.node.glif.io/apigw/lotus
+If you are using the [Glif Lotus RPC Nodes]({{< relref "../developers/glif-nodes" >}}), you do not need to complete this section. Those full-nodes have been configured to accept all incoming requests, so you don't need to create any API keys.
 
 If you are using a node-hosting service like [Infura](https://infura.io/), you may need to create an API key through the service website.
 {{< /alert >}}
@@ -63,7 +61,7 @@ If you are using a node-hosting service like [Infura](https://infura.io/), you m
 
 Next up, you'll create the Lotus executable on your lite-node and running it in _lite_ mode!
 
-## Create the executable
+## Create the lite-node executable
 
 You need to create the Lotus executable to run your lite-node with. This process is the same as when creating a full-node.
 

--- a/content/en/lotus/manage/manage-fil/index.md
+++ b/content/en/lotus/manage/manage-fil/index.md
@@ -83,7 +83,7 @@ waiting for confirmation..
 Created new multisig:  t01004 t2ff7ch2h7qr6f4q5lmvq3ajo6lxucei46attp3ai
 ```
 
-If you want to read more about multisignature wallets and how they function, you can go to the [multisig page]({{< relref "../../manage/multisig" >}})
+If you want to read more about multisignature wallets and how they function, you can go to the [multisig page]({{< relref "../../manage/multisig" >}}).
 
 ## Listing addresses
 

--- a/content/en/lotus/manage/manage-fil/index.md
+++ b/content/en/lotus/manage/manage-fil/index.md
@@ -41,7 +41,7 @@ Because they are more compact than public key addresses, ID addresses are often 
 
 While you can send FIL to an ID address using a wallet, you should first check the details for the account on [FilFox](https://filfox.info/) to see when the account was created, as well as the corresponding public key address. If the address was created very recently (within the [finality period](https://docs.filecoin.io/reference/glossary/#finality)) there is a small chance that it could be re-assigned as the network reaches consensus, and the public key address should be used instead.
 
-More information about addresses can be found in the [How Filecoin works](https://docs.filecoin.io/basics/the-blockchain/addresses/) section.
+More information about addresses can be found in the [Filecoin address docs](https://docs.filecoin.io/basics/the-blockchain/addresses/).
 
 ## Creating a wallet
 

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -68,7 +68,7 @@ This tutorial contains some words and phrases that you might not be familiar wit
 Before you begin storing any data on the Filecoin network, you need to run through a few steps to get everything set up. This section covers getting access to a Lotus full-node, creating a Lotus lite-node on your computer, getting a FIL address, and signing up to Filecoin+.
 
 {{< alert icon="tip" >}}
-Programs that interact with the Filecoin network are called _implementations_, and Lotus is a command-line interface (CLI) implementation. There are other implementation being created alongside Lotus, however Lotus is the only Filecoin implementation created and maintained by Protocol Labs.
+Programs that interact with the Filecoin network are called _implementations_, and Lotus is a command-line interface (CLI) implementation. There are other implementation being created alongside Lotus, however Lotus is the only Filecoin implementation created at Protocol Labs.
 {{< /alert >}}
 
 ### Things to note

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
     <div class="row justify-content-center">
         <div class="col-lg-8">
             <h1 class="mt-0">Lotus</h1>
-            <p class="lead">Lotus is the reference implementation for the Filecoin network. It is written in Go, and is maintained by the Protocol Labs team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!</p>
+            <p class="lead">Lotus is the reference implementation for the Filecoin network. It is written in Go.  It was originally developed at Protocol Labs and is now maintained by the FilOz team. This website contains all the information you need to spin up a Lotus node, become a Filecoin storage provider, or just tinker around with the Filecoin network!</p>
             <p class="lead"><a href="lotus/install/prerequisites/"><b>Install Lotus →</b></a></p>
         </div>
         <div class="col-lg-4 text-center pt-3 d-none d-lg-block">


### PR DESCRIPTION
This is an accumulation of small cleanups while I've been reading through https://lotus.filecoin.io/

Once I get through the docs I'll make a full-list of the changes I made and move this out of draft.

Areas covered:
* Making clearer that FilOz is the maintainer of Lotus now not "Protocol Labs"
* Fixing broken links
* Removing some chain.love references
* Deduplicating some of the build/install steps that are on multiple pages