### PR TITLE
Chore: Set legacy markets tutorial pages to `Draft:true`

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -10,7 +10,7 @@
 
 [[main]]
   name = "Tutorials"
-  url = "/tutorials/lotus/store-and-retrieve/set-up/"
+  url = "/tutorials/lotus/build-with-lotus-api/"
   weight = 30
 
 [[main]]

--- a/content/en/kb/Manage-Storage-Deals-Legacy/index.md
+++ b/content/en/kb/Manage-Storage-Deals-Legacy/index.md
@@ -164,7 +164,7 @@ The delay can be set using the `WaitDealsDelay` option in the `[Sealing]` sectio
 
 ## Offline storage deals
 
-When the amount of data to be transmitted is [very large]({{< relref "large-files#deals-with-offline-data-transfer" >}}), it may be more effective to ship some hard drives directly to the miner and complete the deal in an **offline** fashion.
+When the amount of data to be transmitted is very large, it may be more effective to ship some hard drives directly to the miner and complete the deal in an **offline** fashion.
 
 In this case, the miner will have to import the storage deal data manually with the following command:
 

--- a/content/en/kb/legacy-retrieve-data/index.md
+++ b/content/en/kb/legacy-retrieve-data/index.md
@@ -17,7 +17,7 @@ areas: ["Deprecated"]
  The Legacy Lotus/Lotus-Miner Markets sub-system reached EOL at the [end of the 31st January 2023](https://github.com/filecoin-project/lotus/releases/tag/v1.18.0).
  {{< /alert >}}
 
-Data retrieval is achieved by making a _retrieval deal_ with a _retrieval miner_. In this agreement, the client agrees to pay the miner a certain amount for a given piece of data. This payment happens incrementally as data is received, using a [payment channel]({{< relref "payment-channels" >}}). Unlike storage deals, retrieval deals happen off-chain.
+Data retrieval is achieved by making a _retrieval deal_ with a _retrieval miner_. In this agreement, the client agrees to pay the miner a certain amount for a given piece of data. This payment happens incrementally as data is received, using a payment channel. Unlike storage deals, retrieval deals happen off-chain.
 
 Currently, Lotus supports direct retrieval from the storage miners which originally stored the data, although, per the network's specification, it is planned to support independent retrieval miners that are specifically dedicated to that business by making retrieval an efficient, fast and reliable operation. At that point, clients will be able to search the network for all possible providers of their desired data (via the DHT, the chain, or out-of-band aggregators), compare deal terms, and chose the best retrieval option for their needs.
 

--- a/content/en/tutorials/lotus/backfill-messages.md
+++ b/content/en/tutorials/lotus/backfill-messages.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-lotus"
-weight: 235
+weight: 120
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -6,7 +6,7 @@ menu:
     tutorials:
         parent: "tutorials-lotus"
 aliases:
-weight: 135
+weight: 105
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/disputer.md
+++ b/content/en/tutorials/lotus/disputer.md
@@ -9,7 +9,7 @@ menu:
 aliases:
     - /docs/storage-providers/disputer/
     - /storage-providers/operate/disputer/
-weight: 140
+weight: 110
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/remote-lotus-wallet.md
+++ b/content/en/tutorials/lotus/remote-lotus-wallet.md
@@ -6,7 +6,7 @@ draft: false
 menu:
     tutorials:
         parent: "tutorials-lotus"
-weight: 225
+weight: 115
 toc: true
 ---
 

--- a/content/en/tutorials/lotus/retrieve-data.md
+++ b/content/en/tutorials/lotus/retrieve-data.md
@@ -2,7 +2,7 @@
 title: "Retrieve data"
 description: "There are multiple ways to fetch data from a storage provider. This pages covers some of the most popular methods."
 lead: "There are multiple ways to fetch data from a storage provider. This pages covers some of the most popular methods."
-draft: false
+draft: true
 menu:
     tutorials:
         parent: "tutorials-lotus"


### PR DESCRIPTION
This PR does:
- Remove broken links that originiated from `/Manage-Storage-Deals-Legacy/index.md` and `legacy-retrieve-data/index.md`. Since these pages has been set to `Draft:true`
- Change weights in the Lotus Tutorials pages, so that `Building with Lotus APIs` is the first page that comes up when going to the Tutorials tab.
- Change redirect to `build-with-lotus-api` page in the Tutorials-tab.
- Set retrieve-data tutorial to `Draft:true`