### PR TITLE
Add how to benchmark migration in "online mode"

### DIFF
--- a/content/en/kb/test-migration/index.md
+++ b/content/en/kb/test-migration/index.md
@@ -49,7 +49,7 @@ The last step will create the migration jobs and run through them. You should ob
 
 ## Benchmark migration in online mode
 
-Only run this on a node that you can afford to stop syncing the chain, and can be cleaned up later on.
+Run this only on a node on which you can afford to stop syncing the chain. It can be cleaned up later.
 
 1. On your currently synced and running Lotus node, run:
 


### PR DESCRIPTION
Add how to benchmark migration in "online mode". Adding as KB article, as we run these steps as part of the Burndown-list https://docs.google.com/document/d/11jN9E4IcgcbU_6acAIHuh29v7yGFj7OHiiGYpoUuSEs/edit before a network upgrade