### PR TITLE
fix homebrew instructions

### DIFF
--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -34,7 +34,7 @@ You can quickly install Lotus using Homebrew on macOS.
 1. Install Lotus:
 
     ```shell
-    brew install lotus
+    brew install lotus --formula
     ```
 
 1. You should now have Lotus installed. You can now [start the Lotus daemon]().


### PR DESCRIPTION
`brew install lotus` will install `Lotus.app` instead. This warning is printed:

```
Warning: Treating lotus as a cask. For the formula, use filecoin-project/lotus/lotus or specify the `--formula` flag.
Warning: Not upgrading lotus, the latest version is already installed
```