### PR TITLE
docs: update sections with deprecation notice of `releases` branch

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -165,10 +165,19 @@ Once all the dependencies are installed, you can build and install Lotus.
 1. Switch to the latest stable release branch:
 
     ```shell
-    git checkout releases
+    git pull
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE
     ```
 
-    The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
+    {{< alert >}}
+    The `releases` branch has been deprecated. To get the latest version:\
+    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
+    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
+    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
+    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
+    {{< /alert >}}
+
 
 1. If you are in China, see "[Lotus: tips when running in China]({{< relref "" >}})".
 1. Depending on your CPU model, you will want to export additional environment variables:

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -120,7 +120,8 @@ Because of the novel architecture of the M1-based Mac computers, some specific e
     ```shell
     cd extern/filecoin-ffi
     git fetch -a
-    git checkout releases
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE
     ```
 
 1. Create the `filecoin-ffi` executables:

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -114,10 +114,18 @@ The installation instructions are different depending on which CPU is in your Ma
 1. Switch to the latest stable release branch:
 
     ```shell
-    git checkout releases
+    git pull
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE
     ```
 
-    The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
+    {{< alert >}}
+    The `releases` branch has been deprecated. To get the latest version:\
+    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
+    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
+    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
+    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
+    {{< /alert >}}
 
 1. Create the necessary environment variables to allow Lotus to run on M1 architecture:
 
@@ -157,10 +165,18 @@ These instructions are for installing Lotus on an Intel Mac. If you have an M1-b
 1. Switch to the latest stable release branch:
 
     ```shell
-    git checkout releases
+    git pull
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE
     ```
 
-    The `releases` branch always contains the latest stable release for Lotus. If you want to checkout to a network other than mainnet, take a look at the [Switching networks guide →]({{< relref "switch-networks" >}})
+    {{< alert >}}
+    The `releases` branch has been deprecated. To get the latest version:\
+    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
+    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
+    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
+    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
+    {{< /alert >}}
 
 1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "../../kb/nodes-in-china/" >}})".
 

--- a/content/en/lotus/manage/upgrade.md
+++ b/content/en/lotus/manage/upgrade.md
@@ -18,8 +18,8 @@ Usually, if you are updating Lotus, it as simple as rebuilding and re-installing
 
 ```shell
 git pull
-git checkout releases
-# 'releases' always checks out the latest stable release
+LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+git checkout $LATEST_RELEASE
 # if you need a specific release use 
 # git checkout <tag_or_release>
 git submodule update

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -46,7 +46,8 @@ This section will cover the installation, configuration and running a Lotus seal
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout releases
+    LATEST_RELEASE=$(git tag -l 'miner/v*' | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
+    git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -56,7 +56,8 @@ This section will cover the installation, configuration and starting a lotus nod
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout releases
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1
@@ -154,7 +155,8 @@ This section will cover the installation, configuration, and how to start the lo
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    git checkout releases
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
+    git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
     export FFI_BUILD_FROM_SOURCE=1

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -46,9 +46,8 @@ The following steps walk through how to install a Lotus node.. Further, more det
     ```shell
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus
-    git checkout releases
-    # 'releases' always checks out the latest stable release
-    # if you need a specific release use 
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE # if you need a specific release use 
     git checkout <tag_or_release>
     ```
 

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -138,8 +138,8 @@ If you prefer to build from source, try these steps.
 5. Checkout the latest release
     
     ```shell
-    git checkout releases
-    ```
+    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    git checkout $LATEST_RELEASE    ```
 
 6. Setup some environment variables correctly
     


### PR DESCRIPTION
Update sections that talks about the `releases` branch, with a deprecation notice. Also adding some cmd´s for getting the latest Node | Miner release tags