### PR TITLE
docs: release branch deprecation notice update

### DIFF
--- a/content/en/lotus/developers/local-network.md
+++ b/content/en/lotus/developers/local-network.md
@@ -70,27 +70,21 @@ Filecoin local networks use slightly different binaries than those used in the F
    git checkout <latest-version>
     ```
 
-   {{< alert >}}
-   The `releases` branch has been deprecated. To get the latest version:\
-    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
-    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
-    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
-    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
-    {{< /alert >}}
+   The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
-1. Remove any existing repositories.
+2. Remove any existing repositories.
 
     ```shell
     rm -rf ~/.genesis-sectors
     ```
 
-1. Build the `2k` binary for Lotus:
+3. Build the `2k` binary for Lotus:
 
     ```shell
     make 2k
     ```
 
-1. Fetch the proving parameters for a 2048-byte sector size:
+4. Fetch the proving parameters for a 2048-byte sector size:
 
     ```shell
     ./lotus fetch-params 2048
@@ -104,13 +98,13 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     This command may take several minutes to complete.
 
-1. (**Local network with Fil+**) Build `lotus-shed`:
+5. (**Local network with Fil+**) Build `lotus-shed`:
 
     ```shell
     make lotus-shed
     ```
 
-1. (**Local network with Fil+**) Create a BLS-addresses to serve as the first root key holder:
+6. (**Local network with Fil+**) Create a BLS-addresses to serve as the first root key holder:
 
     ```shell
     ./lotus-shed keyinfo new bls
@@ -122,7 +116,7 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     Make a note of this address `<root-key-1>`, as you will need it in a later step.
 
-1. (**Local network with Fil+**) Create a BLS-addresses to serve as the second root key holder:
+7. (**Local network with Fil+**) Create a BLS-addresses to serve as the second root key holder:
 
     ```shell
     ./lotus-shed keyinfo new bls
@@ -134,7 +128,7 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     Make a note of this address `<root-key-2>`, as you will need it in a later step.
 
-1. Pre-seal 2 sectors for the genesis block:
+8. Pre-seal 2 sectors for the genesis block:
 
     ```shell
     ./lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
@@ -146,7 +140,7 @@ Filecoin local networks use slightly different binaries than those used in the F
     2021-02-23T10:59:36.937-0500    INFO    preseal seed/seed.go:232        Writing preseal manifest to /home/user/.genesis-sectors/pre-seal-t01000.json
     ```
 
-1. Create the genesis block:
+9. Create the genesis block:
 
     ```shell
     ./lotus-seed genesis new localnet.json
@@ -154,13 +148,13 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     This command doesn't output anything on success.
 
-1. (**Local network with Fil+**) Using `<root-key-1>` and `<root-key-2>`, set the root key holders in the genesis block with a signature threshold of 2 for the f080 actor:
+10. (**Local network with Fil+**) Using `<root-key-1>` and `<root-key-2>`, set the root key holders in the genesis block with a signature threshold of 2 for the f080 actor:
 
     ```shell
     ./lotus-seed genesis set-signers --threshold=2 --signers <root-key-1> --signers <root-key-2> localnet.json
     ```
 
-1. Create a pre-miner and an address with some funds:
+11. Create a pre-miner and an address with some funds:
 
     ```shell
     ./lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json

--- a/content/en/lotus/developers/local-network.md
+++ b/content/en/lotus/developers/local-network.md
@@ -72,19 +72,19 @@ Filecoin local networks use slightly different binaries than those used in the F
 
    The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
-2. Remove any existing repositories.
+1. Remove any existing repositories.
 
     ```shell
     rm -rf ~/.genesis-sectors
     ```
 
-3. Build the `2k` binary for Lotus:
+1. Build the `2k` binary for Lotus:
 
     ```shell
     make 2k
     ```
 
-4. Fetch the proving parameters for a 2048-byte sector size:
+1. Fetch the proving parameters for a 2048-byte sector size:
 
     ```shell
     ./lotus fetch-params 2048
@@ -98,13 +98,13 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     This command may take several minutes to complete.
 
-5. (**Local network with Fil+**) Build `lotus-shed`:
+1. (**Local network with Fil+**) Build `lotus-shed`:
 
     ```shell
     make lotus-shed
     ```
 
-6. (**Local network with Fil+**) Create a BLS-addresses to serve as the first root key holder:
+1. (**Local network with Fil+**) Create a BLS-addresses to serve as the first root key holder:
 
     ```shell
     ./lotus-shed keyinfo new bls
@@ -116,7 +116,7 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     Make a note of this address `<root-key-1>`, as you will need it in a later step.
 
-7. (**Local network with Fil+**) Create a BLS-addresses to serve as the second root key holder:
+1. (**Local network with Fil+**) Create a BLS-addresses to serve as the second root key holder:
 
     ```shell
     ./lotus-shed keyinfo new bls
@@ -128,7 +128,7 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     Make a note of this address `<root-key-2>`, as you will need it in a later step.
 
-8. Pre-seal 2 sectors for the genesis block:
+1. Pre-seal 2 sectors for the genesis block:
 
     ```shell
     ./lotus-seed pre-seal --sector-size 2KiB --num-sectors 2
@@ -140,7 +140,7 @@ Filecoin local networks use slightly different binaries than those used in the F
     2021-02-23T10:59:36.937-0500    INFO    preseal seed/seed.go:232        Writing preseal manifest to /home/user/.genesis-sectors/pre-seal-t01000.json
     ```
 
-9. Create the genesis block:
+1. Create the genesis block:
 
     ```shell
     ./lotus-seed genesis new localnet.json
@@ -148,13 +148,13 @@ Filecoin local networks use slightly different binaries than those used in the F
 
     This command doesn't output anything on success.
 
-10. (**Local network with Fil+**) Using `<root-key-1>` and `<root-key-2>`, set the root key holders in the genesis block with a signature threshold of 2 for the f080 actor:
+1. (**Local network with Fil+**) Using `<root-key-1>` and `<root-key-2>`, set the root key holders in the genesis block with a signature threshold of 2 for the f080 actor:
 
     ```shell
     ./lotus-seed genesis set-signers --threshold=2 --signers <root-key-1> --signers <root-key-2> localnet.json
     ```
 
-11. Create a pre-miner and an address with some funds:
+1. Create a pre-miner and an address with some funds:
 
     ```shell
     ./lotus-seed genesis add-miner localnet.json ~/.genesis-sectors/pre-seal-t01000.json

--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -170,13 +170,7 @@ Once all the dependencies are installed, you can build and install Lotus.
     git checkout $LATEST_RELEASE
     ```
 
-    {{< alert >}}
-    The `releases` branch has been deprecated. To get the latest version:\
-    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
-    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
-    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
-    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
-    {{< /alert >}}
+    The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
 
 1. If you are in China, see "[Lotus: tips when running in China]({{< relref "" >}})".

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -119,13 +119,7 @@ The installation instructions are different depending on which CPU is in your Ma
     git checkout $LATEST_RELEASE
     ```
 
-    {{< alert >}}
-    The `releases` branch has been deprecated. To get the latest version:\
-    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
-    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
-    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
-    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
-    {{< /alert >}}
+    The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
 1. Create the necessary environment variables to allow Lotus to run on M1 architecture:
 
@@ -170,13 +164,7 @@ These instructions are for installing Lotus on an Intel Mac. If you have an M1-b
     git checkout $LATEST_RELEASE
     ```
 
-    {{< alert >}}
-    The `releases` branch has been deprecated. To get the latest version:\
-    Lotus Node: `git tag -l 'v*' | sort -V -r | head -n 1`  
-    Lotus Miner: `git tag -l 'miner/v*' | sort -V -r | head -n 1`\
-    If you need a specific release, specify a specific <tag_or_release>. For example: git checkout v1.28.1.\
-    Reference: [Release Policy](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#security-fix-policy)
-    {{< /alert >}}
+    The latest production release can be found on [GitHub](https://github.com/filecoin-project/lotus/releases) or via the [command line](https://github.com/filecoin-project/lotus/blob/master/LOTUS_RELEASE_FLOW.md#why-is-the-releases-branch-deprecated-and-what-are-alternatives).
 
 1. If you are in China, take a look at some [tips for running Lotus in China]({{< relref "../../kb/nodes-in-china/" >}})".
 


### PR DESCRIPTION
This is some followup for https://github.com/filecoin-project/lotus-docs/pull/754 ultimately in support of https://github.com/filecoin-project/lotus/issues/12374

I don't think the `releases` branch deprecation needs to be an alert as I assume most people reading the doc are newer users.  We can also keep the layer of indirection so if we need new commands we change them one place.