### PR TITLE
fix: cmd for getting latest release tag

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -166,7 +166,7 @@ Once all the dependencies are installed, you can build and install Lotus.
 
     ```shell
     git pull
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE
     ```
 

--- a/content/en/lotus/install/lotus-lite.md
+++ b/content/en/lotus/install/lotus-lite.md
@@ -116,7 +116,7 @@ Because of the novel architecture of the M1-based Mac computers, some specific e
     ```shell
     cd extern/filecoin-ffi
     git fetch -a
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE
     ```
 

--- a/content/en/lotus/install/macos.md
+++ b/content/en/lotus/install/macos.md
@@ -115,7 +115,7 @@ The installation instructions are different depending on which CPU is in your Ma
 
     ```shell
     git pull
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE
     ```
 
@@ -160,7 +160,7 @@ These instructions are for installing Lotus on an Intel Mac. If you have an M1-b
 
     ```shell
     git pull
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE
     ```
 

--- a/content/en/lotus/manage/upgrade.md
+++ b/content/en/lotus/manage/upgrade.md
@@ -18,7 +18,7 @@ Usually, if you are updating Lotus, it as simple as rebuilding and re-installing
 
 ```shell
 git pull
-LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
 git checkout $LATEST_RELEASE
 # if you need a specific release use 
 # git checkout <tag_or_release>

--- a/content/en/tutorials/lotus-miner/add-seal-worker.md
+++ b/content/en/tutorials/lotus-miner/add-seal-worker.md
@@ -46,7 +46,7 @@ This section will cover the installation, configuration and running a Lotus seal
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    LATEST_RELEASE=$(git tag -l 'miner/v*' | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
+    LATEST_RELEASE=$(git tag -l 'miner/v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
     git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"

--- a/content/en/tutorials/lotus-miner/run-a-miner.md
+++ b/content/en/tutorials/lotus-miner/run-a-miner.md
@@ -56,7 +56,7 @@ This section will cover the installation, configuration and starting a lotus nod
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"
@@ -155,7 +155,7 @@ This section will cover the installation, configuration, and how to start the lo
     echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus/
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
+    LATEST_RELEASE=$(git tag -l 'miner/v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Miner release
     git checkout $LATEST_RELEASE
     export CGO_CFLAGS_ALLOW="-D__BLST_PORTABLE__"
     export CGO_CFLAGS="-D__BLST_PORTABLE__"

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -46,7 +46,7 @@ The following steps walk through how to install a Lotus node.. Further, more det
     ```shell
     git clone https://github.com/filecoin-project/lotus.git
     cd lotus
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE # if you need a specific release use 
     git checkout <tag_or_release>
     ```

--- a/content/en/tutorials/lotus/store-and-retrieve/set-up.md
+++ b/content/en/tutorials/lotus/store-and-retrieve/set-up.md
@@ -138,7 +138,7 @@ If you prefer to build from source, try these steps.
 5. Checkout the latest release
     
     ```shell
-    LATEST_RELEASE=$(git tag -l 'v*' | sort -V -r | head -n 1) # Finds the latest Lotus Node release
+    LATEST_RELEASE=$(git tag -l 'v*' | grep -v "-" | sort -V -r | head -n 1) # Finds the latest Lotus Node release
     git checkout $LATEST_RELEASE    ```
 
 6. Setup some environment variables correctly


### PR DESCRIPTION
Old cmd worked fine when the latest was a stable release, but when there is a RC out it outputs that. Updating cmd so it only shows latest stable tag.