### PR TITLE
Adds "What is Lotus" in Building with Lotus APIs section

### DIFF
--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -25,6 +25,7 @@ In this tutorial we'll set up a Lotus node locally and use the filecoin.js libra
 Before getting started, you should be familiar with:
 
 - [How Filecoin works](https://docs.filecoin.io/basics/what-is-filecoin/overview/)
+- [What is Lotus](https://lotus.filecoin.io/lotus/get-started/what-is-lotus/)
 - [Using the Lotus command line](https://lotus.filecoin.io/lotus/manage/lotus-cli/)
 
 Also, make sure you have the following dependencies installed with the latest version:

--- a/content/en/tutorials/lotus/build-with-lotus-api.md
+++ b/content/en/tutorials/lotus/build-with-lotus-api.md
@@ -25,7 +25,7 @@ In this tutorial we'll set up a Lotus node locally and use the filecoin.js libra
 Before getting started, you should be familiar with:
 
 - [How Filecoin works](https://docs.filecoin.io/basics/what-is-filecoin/overview/)
-- [What is Lotus](https://lotus.filecoin.io/lotus/get-started/what-is-lotus/)
+- [What is Lotus]({{< relref "../../lotus/get-started/what-is-lotus/" >}})
 - [Using the Lotus command line](https://lotus.filecoin.io/lotus/manage/lotus-cli/)
 
 Also, make sure you have the following dependencies installed with the latest version:


### PR DESCRIPTION
## Description

"What is Lotus" page is excellent — it would be great to have it linked it at the top for better context before setup.

Based on the [Dogfooding Report](https://www.notion.so/filecoin/Lotus-Set-Up-Report-1197631f2825807e90f5cf3ef758e281)


## Screenshot

![Screenshot 2025-04-01 at 14 23 59](https://github.com/user-attachments/assets/af4dd9e1-fb49-49eb-a259-c7eb992e26b0)
