### PR TITLE
Fixes language switcher functionality

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -68,23 +68,28 @@
         <span class="dropdown-caret"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-chevron-down"><polyline points="6 9 12 15 18 9"></polyline></svg></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-end shadow rounded border-0" aria-labelledby="doks-languages">
-
         <li><a class="dropdown-item current" aria-current="true" href="{{ .RelPermalink }}">{{ .Site.Language.LanguageName }}</a></li>
-
         <li><hr class="dropdown-divider"></li>
 
       {{ if .IsTranslated -}}
         {{ range .Translations }}
-          <li><a class="dropdown-item" rel="alternate" href="{{ .RelPermalink }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
+          {{ if eq .Lang "en" }}
+            <li><a class="dropdown-item" rel="alternate" href="/lotus/get-started/what-is-lotus/" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
+          {{ else }}
+            <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}/tutorials/lotus/store-data/" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .Language.LanguageName }}</a></li>
+          {{ end }}
         {{ end -}}
       {{ else -}}
         {{ range .Site.Languages -}}
           {{ if ne $.Site.Language.Lang .Lang }}
-            <li><a class="dropdown-item" rel="alternate" href="{{ .Lang | relLangURL }}" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+            {{ if eq .Lang "en" }}
+              <li><a class="dropdown-item" rel="alternate" href="/lotus/get-started/what-is-lotus/" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+            {{ else }}
+              <li><a class="dropdown-item" rel="alternate" href="/{{ .Lang }}/tutorials/lotus/store-data/" hreflang="{{ .Lang }}" lang="{{ .Lang }}">{{ .LanguageName }}</a></li>
+            {{ end }}
           {{ end -}}
         {{ end -}}
       {{ end -}}
-        <li><hr class="dropdown-divider"></li>
       </ul>
     </div>
     {{ end -}}


### PR DESCRIPTION
## Description

This PR addresses language switcher functionality, as [per dogfooding report](https://www.notion.so/filecoin/Lotus-Set-Up-Report-1197631f2825807e90f5cf3ef758e281). 

- Switching to Mandarin, redirects to `zh/tutorials/lotus/store-data/`
- Switching to English, redirects to `lotus/get-started/what-is-lotus/`


## Previous behaviour

https://github.com/user-attachments/assets/f959eb3b-96fd-432e-8945-56adfefd6dfd

## New behaviour

https://github.com/user-attachments/assets/93899a74-0c75-4550-8c76-cd4032381255

