### PR TITLE
chore: update faucet documentation

### DIFF
--- a/content/en/lotus/manage/manage-fil/index.md
+++ b/content/en/lotus/manage/manage-fil/index.md
@@ -120,7 +120,9 @@ Default address set to: t1ehwusalfn3wrng3zis4rhybdexgrtgsj6vp7fly
 
 ## Obtaining FIL
 
-For non-mainnet networks, `FIL` can be obtained from a faucet. The faucet for the calibration network can [be found here](https://faucet.calibnet.chainsafe-fil.io/funds.html/). For mainnet, the easiest is to buy `FIL` from an exchange. Not all exchanges support `FIL`, so do your research before signing up.
+For non-mainnet networks like Calibration, `FIL` can be obtained from several faucets. You can find a list of Calibration network faucets in the [Calibration network resources section in the Filecoin](https://docs.filecoin.io/networks/calibration#resources) documentation.
+
+For mainnet, there is a [Forest faucet available](https://docs.filecoin.io/networks/mainnet#resources) that distributes very small amounts of FIL (0.01 FIL). For larger amounts, the easiest way is to buy `FIL` from an exchange. Not all exchanges support `FIL`, so do your research before signing up.
 
 Once you have received some `FIL`, use `wallet balance` to check your balance:
 


### PR DESCRIPTION
Closes: #782 

- Replace the single Calibration faucet link with a reference to the complete list of faucets in the Filecoin documentation
- Add information about the Forest faucet for mainnet that provides small amounts of FIL (0.01 FIL)