### PR TITLE
chore: update broken links across Lotus docs

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           args: |
             --accept 100..=103,200..=299,403,429
-            --exclude '(twitter|x)\.com|localhost'
+            --exclude '(twitter|x)\.com|localhost|\{\{.*\}\}'
             --retry-wait-time 15
             '**/*.md'

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           args: |
             --accept 100..=103,200..=299,403,429
-            --exclude '(twitter|x)\.com'
+            --exclude '(twitter|x)\.com|localhost'
             --retry-wait-time 15
             '**/*.md'

--- a/content/en/blog/This-Week-In-Lotus-2022/Week11-23.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week11-23.md
@@ -21,7 +21,7 @@ There have been a lot of FEVM-related questions this week, so here is some docum
 In Lotus, most FEVM-related commands can be found in the `lotus evm` command. Check out all the subcommands with `lotus evm -h`
 
 We also have a couple of new ecosystem services and tooling that you might want to check out:
-- [Glif explorer](https://explorer.glif.io/)
+- [Glif explorer](https://www.glif.io/en)
 - [Beryx explorer](https://beryx.zondax.ch/)
 - [Ankr - node service provider with ETH APIs](https://www.ankr.com/rpc/filecoin/)
 - [Glif - node service provider with ETH APIs](https://hosting.glif.io/)

--- a/content/en/blog/This-Week-In-Lotus-2022/Week27-23.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week27-23.md
@@ -27,7 +27,7 @@ Check out [the full changelog here.](https://github.com/filecoin-project/lotus/b
 
 We often hear from the community that it can be difficult to keep track of the projects and tickets that the Lotus team is engaged in on a week-to-week basis and what the progress of various tasks/issues are. To start addressing this, we have opened our FilCat :cat: GH-project board. This board will display the specific tasks that the team is focusing on during each sprint, making it easier to monitor their status and progress.
 
-We will continue to add our backlog into this board over the coming weeks/months to give it a more full-view of items we are working on. [Check out the FilCat project board here.](https://github.com/orgs/filecoin-project/projects/92)
+We will continue to add our backlog into this board over the coming weeks/months to give it a more full-view of items we are working on.
 
 :bar_chart: **State usage visualization:**
 

--- a/content/en/blog/This-Week-In-Lotus-2022/Week33.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week33.md
@@ -26,7 +26,7 @@ The full documentation :book: for **SplitStoreV2** is currently in review, and w
 - We will start working on the accepted [FIP0034](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0034.md) - `Fix pre-commit deposit independent of sector content` which is scheduled to be included in the nv17 upgrade.
 
 **Lotus community:**
-- The Lotus team will be at both [FIL Singapore](https://fil.org/events/fil-singapore.) and [FIL Lisbon](https://hub.fil.org/fil-lisbon) where we will host a **Lotus & friends day (registration opening soon, stay tuned)**. We hope to see many of you there :smile:.
+- The Lotus team will be at both [FIL Singapore](https://fil.org/events/fil-singapore) and [FIL Lisbon](https://hub.fil.org/fil-lisbon) where we will host a **Lotus & friends day (registration opening soon, stay tuned)**. We hope to see many of you there :smile:.
 - :mega: The authors of the FIP0036 are looking for more [feedback from Lotus-users](https://github.com/filecoin-project/FIPs/discussions/421), and especially want them to check out the [SP return calculator](https://observablehq.com/@starboard/sproi-fip-duration-v2).
 
 That’s it for the week! **Have a great weekend!** :sunny:

--- a/content/en/blog/This-Week-In-Lotus-2022/Week40.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week40.md
@@ -22,7 +22,7 @@ The release has numerous other enhancements and bug fixes, so make sure to [chec
 - Network version 17 is now deployed to the Butterfly network :butterfly: The network will most likely be reset multiple times as we test out different network upgrade test cases.
 
 As you may know by now, we are hosting a Lotus, data onboarding, and friends day on Nov 2nd in Lisbon! The registration for the event is finally open, and the schedule has been finalised. **Come meet us in Lisbon, on Nov 2nd!**
-- Full schedule can be seen here: [https://bit.ly/lotusnfriends](https://lotusandfriends.com/)
+- Full schedule can be seen here: [https://bit.ly/lotusnfriends](https://www.youtube.com/watch?v=LI3K-BkGitg&list=PLhmonklIHGmXfYI9jUxZPx-_HF0REhq5Q)
 - Get your ticket to the event here: [https://bit.ly/lotusnfriends](https://bit.ly/lotusnfriends) 
 
 That´s it for the week! **Have a great weekend!** :sunny:

--- a/content/en/blog/This-Week-In-Lotus-2022/Week41.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week41.md
@@ -21,7 +21,7 @@ The Lotus team will be holding a **Shark :shark: AMA** on Thursday 20th October 
 - Mainnet: `2022-11-09`
 
 :flag-pt: **Lotus, Data Onboarding and friends Day**
-- We have an amazing lineup of speakers for the Lotus, Data Onboarding and friends day: [https://lotusandfriends.com](https://lotusandfriends.com).
+- We have an amazing lineup of speakers for the Lotus, Data Onboarding and friends day: [https://lotusandfriends.com](https://www.youtube.com/playlist?list=PLhmonklIHGmXfYI9jUxZPx-_HF0REhq5Q).
    - There will be deep dives on the lotus-miner, the Filecoin Virtual Machine, and Filecoin Proofs. You will get to know Boost better from presentation held by Boost Core Engineers, there will be panels on the “Path to Become an Enterprise Storage Provider in Filecoin” and a “E2E of Filecoin, Storage, Compute & Retrievals”" workshop. You will get intros to Filecoin Station and Filecoin Saturn, plus many many other interesting talks!!
 - **Ticket are limited and going fast** :zap:️:bullettrain_side:, so secure your spot to the event here: [https://pretix.eu/solaris/lotus-data-onboarding-friends-summit/](https://pretix.eu/solaris/lotus-data-onboarding-friends-summit/).
 

--- a/content/en/blog/This-Week-In-Lotus-2022/Week43.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week43.md
@@ -12,6 +12,6 @@ The Protocol Labs Network has been gathering in Lisbon this week for **LabWeek22
 :flag-pt: **Lotus, Data onboarding and Friends day**
 - It´s only four days until [Lotus, Data onboarding and friends](https://pretix.eu/solaris/lotus-data-onboarding-friends-summit/) day on the 2nd of November. We have an impressive lineup of speakers and are looking forward to seeing everybody there.
 
-Also, a big shoutout :loudspeaker: to the Filecoin Saturn Network :ringed_planet:, a content delivery network (CDN) built on Filecoin which launched this week. Join the #filecoin-saturn in Slack and check out [https://strn.network/](https://strn.network/) for more information about how you can join the network.
+Also, a big shoutout :loudspeaker: to the Filecoin Saturn Network :ringed_planet:, a content delivery network (CDN) built on Filecoin which launched this week. Join the #filecoin-saturn in Slack and check out [https://saturn.tech](https://saturn.tech) for more information about how you can join the network.
 
 That’s it for the week! **Have a great weekend!** :sunny:

--- a/content/en/blog/This-Week-In-Lotus-2022/Week45-23.md
+++ b/content/en/blog/This-Week-In-Lotus-2022/Week45-23.md
@@ -24,8 +24,6 @@ The team has made great progress over the last week with High Availability (HA) 
 
 :hammer_and_wrench: Testing is now well underway and we are already seeing successfully submitted PoSTs using the new HA architecture! Check out the images below which show WindowPoST entries successfully recorded in Yugabyte!
 
-You can follow along with the real-lotus team's progress of SturdyPost and many other exciting planned and in-progress projects on the [FILCAT](https://github.com/orgs/filecoin-project/projects/92/views/2?filterQuery=) tracking board!
-
 **LabWeek23 - A Decentralized Conference by Protocol Labs Network**
 
 Many members of the real-lotus team are now in either Istanbul :flag-tr: or Barcelona :es: for LabWeek23! You can check out the [schedule here](https://23.labweek.io/schedule/calendar) and if you can't make it in person, look out for new videos landing on the Protocol Labs channel during the course of the week. You can [also follow along on Twitter!](https://twitter.com/protocollabs)

--- a/content/en/kb/Actor-Not-Found/index.md
+++ b/content/en/kb/Actor-Not-Found/index.md
@@ -15,7 +15,7 @@ areas: ["sealing", "Lotus Worker", "Lotus Miner"]
 
 ## Problem
 
-Attempting to [create a Lotus deal](https://lotus.filecoin.io/tutorials/lotus/store-and-retrieve/store-data/) results in the following error.
+Attempting to [create a deal](https://lotus.filecoin.io/tutorials/lotus/store-and-retrieve/store-data)) results in the following error.
 
 ```json
 "ERROR: resolve address f1qim...jjy: actor not found"

--- a/content/en/kb/redeclared-sector-log/index.md
+++ b/content/en/kb/redeclared-sector-log/index.md
@@ -26,4 +26,4 @@ These logs appear:
 
 2. Boost added index integrity checks in Boost version v1.7.0 and higher, which is why you would see this logging at certain intervals. The storage list api that Boost relies on in the Lotus-Miner unfortunately doesn’t automatically update removed sectors or removed unsealed copies, so they ask lotus-miner to update the list via the redeclare storage api, which should be a fairly light call.
 
-In Boost you can configure how often this API call occurs in your config file. Check the [Boost documentation for more information.](](https://boost.filecoin.io))
+In Boost you can configure how often this API call occurs in your config file. Check the [Boost documentation for more information](https://boost.filecoin.io).

--- a/content/en/lotus/get-started/networks.md
+++ b/content/en/lotus/get-started/networks.md
@@ -51,7 +51,7 @@ See https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainne
 - [Stats dashboard: Starboard](https://dashboard.starboard.ventures/dashboard)
 - [Slack Channel for Updates: #fil-network-announcements](https://filecoinproject.slack.com/archives/C01AC6999KQ)
 - [Slack Channel for Questions: #fil-help](https://filecoinproject.slack.com/archives/CEGN061C5)
-- [Block explorer: Filfox](https://filfox.io/)
+- [Block explorer: Filfox](https://filfox.info/en)
 - [Block explorer: Filscan](https://filscan.io/)
 - [Block explorer: Filutils](https://www.filutils.com/)
 - [Block explorer: Beryx](https://beryx.io)

--- a/content/en/lotus/manage/ledger/index.md
+++ b/content/en/lotus/manage/ledger/index.md
@@ -81,4 +81,4 @@ The `lotus-shed` application provides additional Ledger functionality, like list
 
 Previously, Ledger Live users were required to install Glif Wallet to store FIL. The Ledger Live integration launched by Zondax is a convenient alternative where holders can enjoy the same benefits within the Ledger Live app without the need for a browser-based solution.
 
-The Glif wallet integration is still available at [glif.io](https://glif.io). Glif is an open-source, browser-based Filecoin wallet. It uses the [Filecoin Ledger integration library](https://github.com/Zondax/ledger-filecoin/), which has been security audited by a third-party.
+The Glif wallet integration is still available at [glif.io](https://www.glif.io/en). Glif is an open-source, browser-based Filecoin wallet. It uses the [Filecoin Ledger integration library](https://github.com/Zondax/ledger-filecoin/), which has been security audited by a third-party.


### PR DESCRIPTION
Closes: #759

Update broken links across Lotus docs, discovered by the link-checker.