### PR TITLE
chore: fix remote-markdown.html so doc publishing works

### DIFF
--- a/layouts/shortcodes/remote-markdown.html
+++ b/layouts/shortcodes/remote-markdown.html
@@ -5,7 +5,7 @@
 {{ $releaseValue := index .Site.Data.version $project }}
 {{ $releaseName := printf $releaseFmt $releaseValue }}
 
-{{ $url := printf "%s?ref=release/%s" $baseUrl $releaseName }}
+{{ $url := printf "%s?ref=%s" $baseUrl $releaseName }}
 
 {{ $response := getJSON $url }}
 {{ $content := $response.content | base64Decode }}


### PR DESCRIPTION
This fixes failed docs publishing workflows like https://github.com/filecoin-project/lotus-docs/runs/40990424517

> 2025-04-23T06:34:43.668Z | ERROR 2025/04/23 06:34:43 Failed to get JSON resource "https://api.github.com/repos/filecoin-project/lotus/contents/documentation/en/cli-lotus-miner.md?ref=release/miner/v1.32.2": Failed to retrieve remote file: Not Found, body: "{"message":"No commit found for the ref release/miner/v1.32.2","documentation_url":"https://docs.github.com/v3/repos/contents/\",\"status\":\"404\"}"

Instead of 
`https://api.github.com/repos/filecoin-project/lotus/contents/documentation/en/cli-lotus-miner.md?ref=release/miner/v1.32.2` we want to do
`https://api.github.com/repos/filecoin-project/lotus/contents/documentation/en/cli-lotus-miner.md?ref=miner/v1.32.2`

This appears safe to make as there are only two callers of this shortcode per https://github.com/search?q=repo%3Afilecoin-project%2Flotus-docs%20remote-markdown&type=code:
1. content/en/lotus/manage/lotus-cli.md
2. content/en/storage-providers/operate/lotus-miner-cli.md