### PR TITLE
chore: update glif-guide

### DIFF
--- a/content/en/lotus/developers/glif-nodes.md
+++ b/content/en/lotus/developers/glif-nodes.md
@@ -96,10 +96,6 @@ lotus net id 12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt
 
 If you want to run a Lotus lite node connected to Glif endpoints, there are some specific considerations:
 
-{{< alert icon="warning" >}}
-When using Lotus v1.33.0 or later with lite nodes, you may encounter WebSocket errors because the lite node assumes the full node supports RPC v2, which Glif nodes do not currently support.
-{{< /alert >}}
-
 For lite node connections without authentication, you can use:
 
 ```shell

--- a/content/en/lotus/developers/glif-nodes.md
+++ b/content/en/lotus/developers/glif-nodes.md
@@ -14,7 +14,7 @@ toc: true
 
 ## Mainnet endpoint
 
-Developers can interact directly with load-balanced, synced mainnet nodes using the [Lotus JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) on the `https://api.node.glif.io` endpoint (or `https://api.node.glif.io/rpc/v0`).
+Developers can interact directly with load-balanced, synced mainnet nodes using the [Lotus JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) on the `https://api.node.glif.io` endpoint (or `https://api.node.glif.io/rpc/v1`).
 
 Unlike bare Lotus, the endpoint above is hardened and limited:
 
@@ -23,11 +23,11 @@ Unlike bare Lotus, the endpoint above is hardened and limited:
 - The Filecoin signing tools can be used to sign messages before submission when needed.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
 - `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes. Alternatively, you can query the Filecoin CID Checker Mongo DB via the [publicly available API](https://filecoin.tools/docs/static/index.html).
-- Mainnet network has a ws (web socket) endpoint. The WebSockets link is available at wss://wss.node.glif.io/apigw/lotus/rpc/v0
+- Mainnet network has a ws (web socket) endpoint. The WebSockets link is available at wss://wss.node.glif.io/apigw/lotus/rpc/1
 
 ## Calibration endpoint
 
-Calibration nodes using the [JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) can use `https://api.calibration.node.glif.io/rpc/v0`.
+Calibration nodes using the [JSON RPC API]({{< relref "../../reference/basics/api-access" >}}) can use `https://api.calibration.node.glif.io/rpc/v1`.
 - Only the _latest_ 2000 blocks are available on public endpoints. This is due to the limitation of [lightweight-snapshots]({{< relref "chain-management" >}}).
 - `Filecoin.StateMarketDeals` operation data is available as a [direct link to an AWS S3 bucket](https://marketdeals-calibration.s3.amazonaws.com/StateMarketDeals.json.zst). `StateMarketDeals` data is refreshed every 10 minutes.
 
@@ -35,7 +35,7 @@ Calibration nodes using the [JSON RPC API]({{< relref "../../reference/basics/ap
 You can use the `v1` JSON RPC API with `https://api.calibration.node.glif.io/rpc/v1`
 {{< /alert >}}
 
-- The Calibration network has a WebSocket endpoint. The WebSlock link is available at wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v0
+- The Calibration network has a WebSocket endpoint. The WebSocket link is available at wss://wss.calibration.node.glif.io/apigw/lotus/rpc/1
 
 ### Custom endpoints
 
@@ -60,12 +60,13 @@ This is an optional step if you need a custom node with special features. You wi
 
 ## Install Lotus and use it as a client
 
-This is an optional step. We can use `lotus` to talk to the Glif node API (as a client). This is useful for two things:
+This is an optional step. We can use `lotus` to talk to the Glif node API (as a client) or run a lite node connected to Glif endpoints. This is useful for several things:
 
 - It allows us to verify that the endpoint works and that credentials are correct when using a custom endpoint.
-- It makes debugging easier was we can try and quickly check things using the `lotus` CLI directly.
+- It makes debugging easier as we can try and quickly check things using the `lotus` CLI directly.
+- You can run a lite node that connects to Glif infrastructure instead of syncing the full chain locally.
 
-To use `lotus`, build or install lotus for [Linux]({{< relref "../install/linux" >}}) or [MacOS]({{< relref "../install/macos" >}}). **The lotus version needs to match that of the running node**. We will not be running the Lotus daemon or syncing the chain; we will use it only as a client.
+To use `lotus`, build or install lotus for [Linux]({{< relref "../install/linux" >}}) or [MacOS]({{< relref "../install/macos" >}}). **The lotus version needs to match that of the running node**. We will not be running the Lotus daemon or syncing the chain; we will use it only as a client, or as a lite node.
 
 Check the running version of the Glif node instance with:
 
@@ -80,6 +81,9 @@ export FULLNODE_API_INFO=<token>:<endpoint>
 
 # For example, with the default URL (no token needed)
 export FULLNODE_API_INFO=https://api.node.glif.io
+
+# For WebSocket connections (useful for lite nodes)
+export FULLNODE_API_INFO=wss://wss.node.glif.io/apigw/lotus/rpc/v1
 ```
 
 You can test that it works with:
@@ -88,7 +92,31 @@ You can test that it works with:
 lotus net id 12D3KooWBF8cpp65hp2u9LK5mh19x67ftAam84z9LsfaquTDSBpt
 ```
 
-If the above does not work, verify that you are using the right token and multiaddress.
+### Using with Lotus lite node
+
+If you want to run a Lotus lite node connected to Glif endpoints, there are some specific considerations:
+
+{{< alert icon="warning" >}}
+When using Lotus v1.33.0 or later with lite nodes, you may encounter WebSocket errors because the lite node assumes the full node supports RPC v2, which Glif nodes do not currently support.
+{{< /alert >}}
+
+For lite node connections without authentication, you can use:
+
+```shell
+FULLNODE_API_INFO=wss://wss.node.glif.io/apigw/lotus ./lotus daemon --lite
+```
+
+However, if you need to provide an API token, you must specify the API version in the URL to avoid routing issues. Use this format:
+
+```shell
+FULLNODE_API_INFO=wss://wss.node.glif.io/apigw/lotus/rpc/v1?token=YOUR_TOKEN ./lotus daemon --lite
+```
+
+This ensures the lite node sends requests to the correct endpoint instead of malformed URLs that won't work with the Glif infrastructure.
+
+{{< alert icon="tip" >}}
+For Calibration network lite nodes, use `wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1?token=YOUR_TOKEN` with the appropriate token.
+{{< /alert >}}
 
 By default, all read operations are enabled, along with the MPoolPush method. This means that you will need to [sign messages yourself](https://docs.filecoin.io/reference/general#message-signing-tools) using your own externally-managed wallets, unless you are given a full node under your full control. We can however, use the CLI to send any read commands. The following are just examples:
 


### PR DESCRIPTION
Update the glif-guide based on [Slack thread](https://filecoinproject.slack.com/archives/CP50PPW2X/p1749465354757829?thread_ts=1749306816.625039&cid=CP50PPW2X): 
- API Version Updates (v0 → v1)
- Included warning about Lotus v1.33.0+ compatibility issues with RPC v2
   - Without authentication: wss://wss.node.glif.io/apigw/lotus
   - With token: wss://wss.node.glif.io/apigw/lotus/rpc/v1?token=YOUR_TOKEN