### PR TITLE
Correct link to the Slack

### DIFF
--- a/content/en/lotus/developers/contribute.md
+++ b/content/en/lotus/developers/contribute.md
@@ -1,7 +1,7 @@
 ---
 title: "Contribute"
-description: "So you want to contribute to Lotus? Here is a quick listing of things we need help with and how you can get started. Even if what you want to do is not listed here, we probably accept contributions for it! If you're unsure, please open a issue."
-lead: "So you want to contribute to Lotus? Here is a quick listing of things we need help with and how you can get started. Even if what you want to do is not listed here, we probably accept contributions for it! If you're unsure, please open a issue."
+description: "So you want to contribute to Lotus? Here is a quick listing of things we need help with and how you can get started. Even if what you want to do is not listed here, we probably accept contributions for it! If you're unsure, please open an issue."
+lead: "So you want to contribute to Lotus? Here is a quick listing of things we need help with and how you can get started. Even if what you want to do is not listed here, we probably accept contributions for it! If you're unsure, please open an issue."
 draft: false
 menu:
     lotus:
@@ -14,7 +14,7 @@ toc: true
 
 ## Code
 
-Lotus, the reference implementation of Filecoin and its sister-projects are big, with lots of code written in multiple languages. We always need help writing and maintaining code, but it can be daunting to just jump in. We use the label _Help Wanted_ on features or bugfixes that people can help out with. They are an excellent place for you to start contributing code.
+Lotus, the reference implementation of Filecoin and its sister-projects, is big, with lots of code written in multiple languages. We always need help writing and maintaining code, but it can be daunting to just jump in. We use the label _Help Wanted_ on features or bugfixes that people can help out with. They are an excellent place for you to start contributing code.
 
 The biggest and most active repositories we have today are:
 
@@ -23,7 +23,7 @@ The biggest and most active repositories we have today are:
 - [filecoin-project/ref-fvm](https://github.com/filecoin-project/ref-fvm)
 - [filecoin-project/rust-fil-proofs](https://github.com/filecoin-project/rust-fil-proofs)
 
-If you want to start contributing to the core of Filecoin, those repositories are a great place start. 
+If you want to start contributing to the core of Filecoin, those repositories are a great place to start. 
 
 But the _Help Wanted_ label also exists in several related projects:
 
@@ -36,9 +36,9 @@ But the _Help Wanted_ label also exists in several related projects:
 
 The Filecoin community is active and here to answer your questions in your channel of choice.
 
-For shorter-lived discussions, our community chat is open to all on [Slack](https://filecoin.io/slack/) in the #fil-lotus-dev channel.
+For shorter-lived discussions, our community chat is open to all on [Slack](https://filecoinproject.slack.com/) in the #fil-lotus-dev channel.
 
-For long-lived discussions and for support, please use [Lotus GitHub discussions](https://github.com/filecoin-project/lotus/discussions) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.
+For long-lived discussions and support, please use [Lotus GitHub discussions](https://github.com/filecoin-project/lotus/discussions) instead of Slack. It’s easy for complex discussions to get lost in a sea of new messages on those chat platforms, and posting longer discussions and support requests on the forums helps future visitors, too.
 
 ## Build Applications
 


### PR DESCRIPTION
The link is corrected to the current Filecoin Slack project, along with a couple of grammar corrections. The previous link was responding with 404.