### PR TITLE
Still broken link to Start-lotus page

### DIFF
--- a/content/en/lotus/install/linux.md
+++ b/content/en/lotus/install/linux.md
@@ -229,7 +229,8 @@ Once all the dependencies are installed, you can build and install Lotus.
    lotus version 1.23.3+calibnet+git.7bb1f98ac
    ```
 
-1. You should now have Lotus installed. You can now [start the Lotus daemon]({{< relref "../install/start-lotus/#start-the-lotus-daemon" >}}
+1. You should now have Lotus installed. You can now [start the Lotus daemon]({{< relref "start-lotus.md#start-the-lotus-daemon" >}})
+
 
 ### Native Filecoin FFI
 


### PR DESCRIPTION
I've fixed the missing closing parentheses and the unnecessary file path.
WARNING: I couldn't test, since in the Preview mode, the relrefs are not generated properly. 
To verify after deploy, check the page [https://lotus.filecoin.io/lotus/install/linux/](https://lotus.filecoin.io/lotus/install/linux/)

FYI: The previous attempt to fix in [PR #812](https://github.com/filecoin-project/lotus-docs/pull/812). :sweat_smile: 